### PR TITLE
build: Remove needless warnings

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,11 +5,12 @@ steps:
       queue: bazel
     key: build
     command: |
-      apt-get update -y && apt-get install -y gcc-10 gcc-10-base g++-10 libstdc++-10-dev
-      update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
-      echo "--- gcc"
-      gcc -v
-      echo "--- gcc"
+      curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+      add-apt-repository 'deb http://apt.llvm.org/focal/  llvm-toolchain-focal-15 main'
+      apt-get install -y clang-15
+      export CC=clang-15
+      export CXX=clang++-15
+      "$CC" --version
 
       bazel build //...
 

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,6 +5,8 @@ steps:
       queue: bazel
     key: build
     command: |
+      lsb_release -a
+      set +x
       curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
       add-apt-repository 'deb http://apt.llvm.org/focal/  llvm-toolchain-focal-15 main'
       apt-get install -y clang-15

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,14 +5,11 @@ steps:
       queue: bazel
     key: build
     command: |
-      lsb_release -a
-      set +x
       curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
       add-apt-repository 'deb http://apt.llvm.org/focal/  llvm-toolchain-focal-15 main'
       apt-get install -y clang-15
       export CC=clang-15
       export CXX=clang++-15
-      "$CC" --version
 
       bazel build //...
 

--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -58,6 +58,7 @@ cc_library(
     copts = [
         "-Wno-unused-variable",
         "-Wno-implicit-function-declaration",
+        "-Wno-deprecated-non-prototype",
     ],
     includes = ["zlib/include/"],
 )


### PR DESCRIPTION
* Use Clang in CI because of GCC's silly -Wreturn-type warnings
  on exhaustive switches over enum class values.

Fixes #9.
