### PR TITLE
chore: Remove new Clang 15/GCC 12 warning.

### DIFF
--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -58,7 +58,9 @@ cc_library(
     copts = [
         "-Wno-unused-variable",
         "-Wno-implicit-function-declaration",
-        "-Wno-deprecated-non-prototype",
+        # Uncomment this flag once we start using Clang 15 for builds.
+        # Right now, the latest Xcode (14) uses Apple Clang 14.
+        # "-Wno-deprecated-non-prototype",
     ],
     includes = ["zlib/include/"],
 )


### PR DESCRIPTION
- fix: Delete job from WIP set on killing worker.
- chore: Remove new Clang 15/GCC 12 warning.
