### PR TITLE
build: Add protobuf generation for SCIP schema.

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -4,6 +4,7 @@ load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")
 load("@llvm_upstream//utils/bazel:configure.bzl", "llvm_configure")
 load("@llvm_upstream//utils/bazel:terminfo.bzl", "llvm_terminfo_disable")
 load("@llvm_upstream//utils/bazel:zlib.bzl", "llvm_zlib_external")
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 def scip_clang_dependencies():
     bazel_skylib_workspace()
@@ -11,8 +12,10 @@ def scip_clang_dependencies():
     bazel_compdb_deps()
 
     llvm_terminfo_disable(name = "llvm_terminfo")
-    llvm_zlib_external(name = "llvm_zlib", external_zlib = "@net_zlib//:zlib")
+    llvm_zlib_external(name = "llvm_zlib", external_zlib = "@zlib//:zlib")
 
     # FIXME: Should we allow all targets in a release build?
     # Limit the number of backends here to save on compile time for now.
     llvm_configure(name = "llvm-project", targets = ["AArch64", "X86"])
+
+    protobuf_deps()

--- a/indexer/BUILD
+++ b/indexer/BUILD
@@ -29,6 +29,7 @@ cc_library(
         "@llvm-project//clang:ast",
         "@llvm-project//clang:frontend",
         "@llvm-project//clang:tooling",
+        "@scip",
     ],
 )
 

--- a/indexer/Worker.cc
+++ b/indexer/Worker.cc
@@ -34,6 +34,8 @@
 #include "indexer/Path.h"
 #include "indexer/Worker.h"
 
+#include "scip/scip.pb.h"
+
 namespace boost_ip = boost::interprocess;
 
 namespace scip_clang {

--- a/setup.bzl
+++ b/setup.bzl
@@ -9,6 +9,8 @@ _CXXOPTS_VERSION = "3.0.0"
 _RAPIDJSON_COMMIT = "a98e99992bd633a2736cc41f96ec85ef0c50e44d"
 _WYHASH_COMMIT = "ea3b25e1aef55d90f707c3a292eeb9162e2615d8"
 _SPDLOG_COMMIT = "edc51df1bdad8667b628999394a1e7c4dc6f3658"
+_PROTOBUF_VERSION = "3.21.12"
+_SCIP_COMMIT = "aa0e511dcfefbacc3b96dcc2fe2abd9894416b1e"
 
 _DOCTEST_VERSION = "2.4.9"
 _DTL_VERSION = "1.20"
@@ -46,8 +48,11 @@ def scip_clang_rule_repositories():
         urls = ["https://github.com/grailbio/bazel-compilation-database/archive/0.5.2.tar.gz"],
     )
 
+    # Keep the name 'zlib' so that Protobuf doesn't pull in another copy.
+    #
+    # https://sourcegraph.com/github.com/protocolbuffers/protobuf/-/blob/protobuf_deps.bzl?L48-58
     http_archive(
-        name = "net_zlib",
+        name = "zlib",
         build_file = "@scip_clang//third_party:zlib.BUILD",
         sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
         strip_prefix = "zlib-1.2.11",
@@ -65,6 +70,25 @@ def scip_clang_rule_repositories():
         urls = ["https://github.com/llvm/llvm-project/archive/%s.tar.gz" % _LLVM_COMMIT],
     )
 
+    http_archive(
+        name = "com_google_protobuf",
+        sha256 = "f7042d540c969b00db92e8e1066a9b8099c8379c33f40f360eb9e1d98a36ca26",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v%s.zip" % _PROTOBUF_VERSION],
+        strip_prefix = "protobuf-%s" % _PROTOBUF_VERSION,
+    )
+
+    http_archive(
+        name = "scip",
+        sha256 = "b1d2fc009345857aa32cdddec11b75ce1e5c20430f668044231ed309d48b7355",
+        build_file = "@scip_clang//third_party:scip.BUILD",
+        strip_prefix = "scip-%s" % _SCIP_COMMIT,
+        urls = ["https://github.com/sourcegraph/scip/archive/%s.zip" % _SCIP_COMMIT],
+    )
+
+    # Keep the name 'com_google_absl' so that Protobuf doesn't pull in
+    # another copy.
+    #
+    # https://sourcegraph.com/github.com/protocolbuffers/protobuf/-/blob/protobuf_deps.bzl?L39-46
     http_archive(
         name = "com_google_absl",
         sha256 = "0db3f1408edf4e0eb12bd6c46fc01465a009feb2789a2b21ef40f91744a25783",

--- a/third_party/scip.BUILD
+++ b/third_party/scip.BUILD
@@ -1,0 +1,15 @@
+load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library")
+
+cc_proto_library(
+    name = "proto",
+    srcs = ["scip.proto"],
+)
+
+cc_library(
+    name = "scip",
+    srcs = ["scip.pb.cc"],
+    hdrs = ["scip.pb.h"],
+    deps = [":proto"],
+    include_prefix = "scip",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Instead of vendoring, pull it in from upstream to easily
track the difference between latest upstream
and used schema.
