### PR TITLE
chore: Turn on -Wunused-params.

### DIFF
--- a/indexer/BUILD
+++ b/indexer/BUILD
@@ -7,6 +7,10 @@ cc_library(
         ],
         exclude = ["main.cc"],
     ),
+    copts = [
+        # Not part of -Wall but still useful
+        "-Wunused-parameter",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//indexer/os",

--- a/indexer/CompilationDatabase.cc
+++ b/indexer/CompilationDatabase.cc
@@ -123,14 +123,14 @@ public:
     return false;
   }
   bool Uint64(uint64_t i) {
-    this->errorMessage = fmt::format("unexpected uint64_t {}");
+    this->errorMessage = fmt::format("unexpected uint64_t {}", i);
     return false;
   }
   bool Double(double d) {
     this->errorMessage = fmt::format("unexpected double {}", d);
     return false;
   }
-  bool RawNumber(const char *str, rapidjson::SizeType length, bool copy) {
+  bool RawNumber(const char *str, rapidjson::SizeType length, bool /*copy*/) {
     this->errorMessage =
         fmt::format("unexpected number {}", std::string_view(str, length));
     return false;
@@ -285,7 +285,7 @@ static size_t validateAndCountJobs(size_t fileSize, FILE *compDbFile) {
 }
 
 bool CommandObjectHandler::String(const char *str, rapidjson::SizeType length,
-                                  bool copy) {
+                                  bool /*copy*/) {
   switch (this->previousKey) {
   case Key::Unset:
     ENFORCE(false, "unexpected input");
@@ -312,7 +312,7 @@ bool CommandObjectHandler::String(const char *str, rapidjson::SizeType length,
 }
 
 bool CommandObjectHandler::Key(const char *str, rapidjson::SizeType length,
-                               bool copy) {
+                               bool /*copy*/) {
   auto key = std::string_view(str, length);
   if (key == "directory") {
     this->previousKey = Key::Directory;
@@ -330,7 +330,7 @@ bool CommandObjectHandler::Key(const char *str, rapidjson::SizeType length,
   return true;
 }
 
-bool CommandObjectHandler::EndObject(rapidjson::SizeType memberCount) {
+bool CommandObjectHandler::EndObject(rapidjson::SizeType /*memberCount*/) {
   this->commands.emplace_back(std::move(this->wipCommand));
   this->wipCommand = {};
   this->previousKey = Key::Unset;

--- a/indexer/Driver.cc
+++ b/indexer/Driver.cc
@@ -452,6 +452,7 @@ public:
   /// Call \c openCompilationDatabase before this method. The \p _compdbToken
   /// parameter is present to accidentally avoid flipping call order.
   void spawnWorkers(const FileGuard &_compdbToken) {
+    (void)_compdbToken;
     this->scheduler.initializeWorkers(
         this->numWorkers(), [&](WorkerId workerId) -> Scheduler::Process {
           return this->spawnWorker(workerId);
@@ -539,7 +540,7 @@ private:
         });
   }
 
-  void processSemanticAnalysisResult(SemanticAnalysisJobResult &&result) {}
+  void processSemanticAnalysisResult(SemanticAnalysisJobResult &&) {}
 
   void processWorkerResponse(IndexJobResponse &&response) {
     this->scheduler.markCompleted(response.workerId, response.jobId,

--- a/indexer/Timer.cc
+++ b/indexer/Timer.cc
@@ -41,7 +41,8 @@ static scip_clang::Microseconds getCurrentInstantCoarse() {
 
 namespace scip_clang {
 
-void timingAdd(ConstExprStr key, Microseconds start, Microseconds end) {
+void timingAdd(ConstExprStr /*key*/, Microseconds /*start*/,
+               Microseconds /*end*/) {
   // FIXME: Copy the necessary bits of the timing infrastructure from Sorbet.
 }
 

--- a/indexer/Worker.cc
+++ b/indexer/Worker.cc
@@ -367,7 +367,7 @@ public:
   virtual void
   FileChanged(clang::SourceLocation sourceLoc,
               clang::PPCallbacks::FileChangeReason reason,
-              clang::SrcMgr::CharacteristicKind fileType,
+              clang::SrcMgr::CharacteristicKind /*fileType*/,
               clang::FileID previousFileId = clang::FileID()) override {
     using Reason = clang::PPCallbacks::FileChangeReason;
     switch (reason) {
@@ -439,8 +439,9 @@ class IndexerASTConsumer : public clang::SemaConsumer {
   clang::Sema *sema;
 
 public:
-  IndexerASTConsumer(clang::CompilerInstance &compilerInstance,
-                     llvm::StringRef filepath) {}
+  IndexerASTConsumer(clang::CompilerInstance &, llvm::StringRef filepath) {
+    (void)filepath;
+  }
 
   void HandleTranslationUnit(clang::ASTContext &astContext) override {
     IndexerASTVisitor visitor{};
@@ -498,8 +499,8 @@ public:
 
 class IndexerDiagnosticConsumer : public clang::DiagnosticConsumer {
 public:
-  void HandleDiagnostic(clang::DiagnosticsEngine::Level level,
-                        const clang::Diagnostic &info) override {
+  void HandleDiagnostic(clang::DiagnosticsEngine::Level,
+                        const clang::Diagnostic &) override {
     // Just dropping all diagnostics on the floor for now.
     // FIXME(def: surface-diagnostics)
   }


### PR DESCRIPTION
I just spent over an hour debugging a bug which looked like a UAF
but the problem was that I was forgetting to use a parameter in
a constructor. Turns out -Wunused-params is not turned on by -Wall.
