### PR TITLE
refactor: Make snapshot testing code more flexible

### DIFF
--- a/indexer/Path.cc
+++ b/indexer/Path.cc
@@ -80,6 +80,14 @@ std::strong_ordering operator<=>(const RootRelativePathRef &lhs,
   return std::strong_ordering::equal;
 }
 
+RootRelativePath::RootRelativePath(RootRelativePathRef ref)
+    : value(ref.asStringView()), _kind(ref.kind()) {
+  if (this->value.empty()) {
+    return;
+  }
+  ENFORCE(llvm::sys::path::is_relative(this->value));
+}
+
 std::optional<RootRelativePathRef>
 RootPath::tryMakeRelative(AbsolutePathRef maybePathInsideProject) const {
   if (auto optStrView =

--- a/indexer/Path.h
+++ b/indexer/Path.h
@@ -106,6 +106,31 @@ public:
 
   friend std::strong_ordering operator<=>(const RootRelativePathRef &,
                                           const RootRelativePathRef &);
+  DERIVE_EQ_VIA_CMP(RootRelativePathRef)
+};
+
+class RootRelativePath {
+  std::string value;
+  RootKind _kind;
+
+public:
+  RootRelativePath() = default;
+  RootRelativePath(RootRelativePath &&) = default;
+  RootRelativePath &operator=(RootRelativePath &&) = default;
+  RootRelativePath(const RootRelativePath &) = default;
+  RootRelativePath &operator=(const RootRelativePath &) = default;
+
+  explicit RootRelativePath(RootRelativePathRef ref);
+
+  const std::string &asStringRef() const {
+    return this->value;
+  }
+
+  RootRelativePathRef asRef() const {
+    return RootRelativePathRef(this->value, this->_kind);
+  }
+
+  DERIVE_HASH_CMP_NEWTYPE(RootRelativePath, asRef(), CMP_EXPR)
 };
 
 class RootPath final {

--- a/test/BUILD
+++ b/test/BUILD
@@ -4,7 +4,13 @@ load(":test_suite.bzl", "scip_clang_test_suite")
 cc_binary(
     name = "test_main",
     testonly = 1,
-    srcs = ["test_main.cc"],
+    srcs = glob(
+        [
+            "*.cc",
+            "*.h",
+        ],
+        exclude = ["ipc_test_main.cc"],
+    ),
     linkopts = select({
         "//:asan_linkopts": ASAN_LINKOPTS,
         "//conditions:default": [],

--- a/test/Snapshot.cc
+++ b/test/Snapshot.cc
@@ -1,0 +1,152 @@
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/str_replace.h"
+#include "absl/strings/str_split.h"
+#include "doctest/doctest.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsuggest-override"
+#include "dtl/dtl.hpp"
+#pragma clang diagnostic pop
+#include "spdlog/fmt/fmt.h"
+
+#include "indexer/AbslExtras.h"
+#include "indexer/Enforce.h"
+#include "indexer/FileSystem.h"
+
+#include "test/Snapshot.h"
+
+using namespace scip_clang;
+
+void compareDiff(std::string_view expected, std::string_view actual,
+                 std::string_view errorMessage) {
+  if (expected == actual) {
+    return;
+  }
+
+  std::vector<std::string> expectedLines = absl::StrSplit(expected, '\n');
+  std::vector<std::string> actualLines = absl::StrSplit(actual, '\n');
+  dtl::Diff<std::string, std::vector<std::string>> diff(expectedLines,
+                                                        actualLines);
+  diff.compose();
+  diff.composeUnifiedHunks();
+
+  std::stringstream ss;
+  diff.printUnifiedFormat(ss);
+  FAIL_CHECK(fmt::format("{}\n{}", errorMessage, ss.str()));
+}
+
+static std::vector<RootRelativePath> listFilesRecursive(const RootPath &root) {
+  std::vector<RootRelativePath> out;
+  std::filesystem::recursive_directory_iterator it(root.asRef().asStringView());
+  for (auto &dirEntry : it) {
+    if (!dirEntry.is_directory()) {
+      std::string path = dirEntry.path().string();
+      if (llvm::sys::path::is_absolute(path)) {
+        out.emplace_back(
+            root.tryMakeRelative(
+                    AbsolutePathRef::tryFrom(std::string_view(path)).value())
+                .value());
+      } else {
+        out.emplace_back(RootRelativePathRef{path, root.kind()});
+      }
+    }
+  }
+  absl::c_sort(out);
+  return out;
+}
+
+namespace scip_clang {
+namespace test {
+
+std::string readFileToString(const StdPath &path) {
+  std::ifstream in(path.c_str(), std::ios_base::in | std::ios_base::binary);
+  return std::string((std::istreambuf_iterator<char>(in)),
+                     std::istreambuf_iterator<char>());
+}
+
+void compareOrUpdateSingleFile(SnapshotMode mode, std::string_view actual,
+                               const StdPath &snapshotFilePath) {
+  switch (mode) {
+  case SnapshotMode::Compare: {
+    std::string expected(test::readFileToString(snapshotFilePath));
+    ::compareDiff(expected, actual, "comparison failed");
+    return;
+  }
+  case SnapshotMode::Update: {
+    std::ofstream out(snapshotFilePath.c_str(),
+                      std::ios_base::out | std::ios_base::binary);
+    out.write(actual.data(), actual.size());
+  }
+  }
+}
+
+MultiTuSnapshotTest::MultiTuSnapshotTest(
+    RootPath &&root,
+    absl::FunctionRef<std::optional<RootRelativePath>(const RootRelativePath &)>
+        getSnapshotPath)
+    : rootPath(std::move(root)), inputOutputs() {
+  auto inputFiles = ::listFilesRecursive(this->rootPath);
+  for (auto &inputFile : inputFiles) {
+    if (auto optSnapshotPath = getSnapshotPath(inputFile)) {
+      this->inputOutputs.emplace_back(InputOutput{
+          std::move(inputFile), std::move(optSnapshotPath.value())});
+    }
+  }
+}
+
+void MultiTuSnapshotTest::run(SnapshotMode mode,
+                              RunCompileCommandCallback compute) {
+  absl::flat_hash_map<RootRelativePathRef, RootRelativePathRef>
+      inputToOutputMap;
+  for (auto &io : this->inputOutputs) {
+    inputToOutputMap.insert(
+        {io.sourceFilePath.asRef(), io.snapshotPath.asRef()});
+  }
+
+  for (auto &io : this->inputOutputs) {
+    auto &sourceFilePath = io.sourceFilePath.asStringRef();
+    if (!test::isTuMainFilePath(sourceFilePath)) {
+      continue;
+    }
+    clang::tooling::CompileCommand command{};
+    command.Directory = rootPath.asRef().asStringView();
+    command.CommandLine = {
+        "clang",
+        "-I",
+        ".",
+        sourceFilePath,
+    };
+    command.Filename =
+        rootPath.makeAbsolute(io.sourceFilePath.asRef()).asStringRef();
+    auto output = compute(std::move(command));
+
+    extractTransform(
+        std::move(output), /*deterministic*/ true,
+        absl::FunctionRef<void(RootRelativePath &&, std::string &&)>(
+            [&](auto &&inputPath, auto &&snapshotContent) -> void {
+              auto it = inputToOutputMap.find(inputPath.asRef());
+              ENFORCE(it != inputToOutputMap.end());
+              auto absPath = rootPath.makeAbsolute(it->second);
+              test::compareOrUpdateSingleFile(mode, snapshotContent,
+                                              absPath.asStringRef());
+            }));
+  }
+}
+
+bool isTuMainFilePath(std::string_view p) {
+  auto dotIndex = p.rfind('.');
+  if (dotIndex == std::string::npos) {
+    return false;
+  }
+  auto ext = p.substr(dotIndex);
+  return ext == ".cc" || ext == ".cpp" || ext == ".cxx" || ext == ".c";
+}
+
+} // namespace test
+} // namespace scip_clang

--- a/test/Snapshot.h
+++ b/test/Snapshot.h
@@ -1,0 +1,63 @@
+#ifndef SCIP_CLANG_TEST_SNAPSHOT_H
+#define SCIP_CLANG_TEST_SNAPSHOT_H
+
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/functional/function_ref.h"
+
+#include "clang/Tooling/CompilationDatabase.h"
+
+#include "indexer/FileSystem.h"
+#include "indexer/Path.h"
+
+namespace scip_clang {
+namespace test {
+
+std::string readFileToString(const StdPath &);
+
+enum class SnapshotMode {
+  Compare,
+  Update,
+};
+
+bool isTuMainFilePath(std::string_view);
+
+class MultiTuSnapshotTest final {
+  RootPath rootPath;
+  struct InputOutput {
+    RootRelativePath sourceFilePath;
+    RootRelativePath snapshotPath;
+  };
+
+  std::vector<InputOutput> inputOutputs;
+
+public:
+  MultiTuSnapshotTest(RootPath &&,
+                      absl::FunctionRef<std::optional<RootRelativePath>(
+                          const RootRelativePath &)>
+                          getSnapshotPath);
+
+  using RunCompileCommandCallback =
+      absl::FunctionRef<absl::flat_hash_map<RootRelativePath, std::string>(
+          clang::tooling::CompileCommand &&command)>;
+
+  void run(SnapshotMode, RunCompileCommandCallback);
+};
+
+void compareOrUpdateSingleFile(SnapshotMode mode, std::string_view actual,
+                               const StdPath &snapshotFilePath);
+
+// Perform a line-wise diff of expected vs actual.
+//
+// NOTE(ref: based-on-sorbet): This function implementation was originally
+// in Sorbet's expectations.cc named as CHECK_EQ_DIFF
+void compareDiff(std::string_view expected, std::string_view actual,
+                 std::string_view errorMessage);
+
+} // namespace test
+} // namespace scip_clang
+
+#endif // SCIP_CLANG_TEST_SNAPSHOT_H


### PR DESCRIPTION
- Allow returning multiple snapshot outputs per TU instead
  of just a single output
- Use a narrower RootRelativePath type for clarity instead of
  using std::filesystem::path everywhere
