### PR TITLE
fix: Turn on sandboxing for tests again

### DIFF
--- a/indexer/Driver.cc
+++ b/indexer/Driver.cc
@@ -835,8 +835,8 @@ private:
 } // namespace
 
 int driverMain(CliOptions &&cliOptions) {
-  pid_t driverPid = ::getpid();
-  auto driverId = fmt::format("{}", driverPid);
+  auto driverId = cliOptions.driverId.empty() ? fmt::format("{}", ::getpid())
+                                              : cliOptions.driverId;
   size_t numWorkers = cliOptions.numWorkers;
   BOOST_TRY {
     Driver driver(driverId, DriverOptions(driverId, std::move(cliOptions)));

--- a/indexer/main.cc
+++ b/indexer/main.cc
@@ -86,7 +86,9 @@ static scip_clang::CliOptions parseArguments(int argc, char *argv[]) {
     cxxopts::value<std::string>(cliOptions.workerMode)->default_value(""));
   parser.add_options("Internal")(
     "driver-id",
-    "[worker-only] An opaque ID for the driver.",
+    "An opaque ID for the driver. Normally, this is only used by the driver "
+    "to communicate with the worker, but it may be used to set the driver ID "
+    "in tests as the PID is deterministic in a Bazel sandbox.",
     cxxopts::value<std::string>(cliOptions.driverId));
   parser.add_options("Internal")(
     "worker-id",

--- a/test/ipc_test_main.cc
+++ b/test/ipc_test_main.cc
@@ -101,7 +101,7 @@ int main(int argc, char *argv[]) {
   if (argc == 3) {
     driverId = std::string(argv[2]);
   } else {
-    driverId = fmt::format("{}", ::getpid());
+    driverId = "ipc-test" + std::string(argv[1]);
   }
   scip_clang::IpcOptions ipcOptions{1s, driverId, 0};
   Mode mode = ::modeFromString(argv[1]);

--- a/test/test_main.cc
+++ b/test/test_main.cc
@@ -317,6 +317,7 @@ TEST_CASE("ROBUSTNESS") {
   args.push_back("--force-worker-fault=" + fault);
   args.push_back("--testing");
   args.push_back("--receive-timeout-seconds=3");
+  args.push_back(fmt::format("--driver-id=robustness-{}", fault));
   TempFile tmpLogFile(fmt::format("{}.tmp.log", fault));
   boost::process::child driver(args,
                                boost::process::std_out > boost::process::null,

--- a/test/test_suite.bzl
+++ b/test/test_suite.bzl
@@ -19,11 +19,8 @@ def _ipc_test(name, args):
         data = ["//test:ipc_test_main"],
         env = {"TEST_MAIN": "./test/ipc_test_main"},
         size = "small",
-        # Don't sandbox because we want different driver processes
-        # to have different PIDs to be able to run the tests in
-        # parallel
         # Don't cache because the test can be non-deterministic
-        tags = ["no-sandbox", "no-cache"],
+        tags = ["no-cache"],
     )
 
 def _snapshot_test(name, kind, data, tags = []):
@@ -83,7 +80,7 @@ def _robustness_tests(data):
             data = data + ["//indexer:scip-clang"],
             # no-cache doesn't work sometimes, so add "external" 😔
             # https://github.com/bazelbuild/bazel/issues/15516
-            tags = ["no-sandbox", "no-cache", "external"],
+            tags = ["no-cache", "external"],
         )
         tests.append(test_name)
         updates.append(update_name)


### PR DESCRIPTION
For some reason, I didn't think of passing in the test name
as the driver ID earlier, just realized this while trying to
figure out why the namespace tests were failing in #76