### PR TITLE
ci: Add extra .bazelrc in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
+try-import %workspace%/ci.bazelrc
+
 # Not sure why setting all of these is necessary, but just setting cxxopt
 # Leads to usage of old C++ version when compiling LLVM, which needs C++14 or newer.
 build --cxxopt="-std=c++20" --host_cxxopt="-std=c++20" --client_env=BAZEL_CXXOPTS="-std=c++20"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,8 +12,10 @@ steps:
       chmod +x buildifier
       mv buildifier /usr/local/bin/
 
+
+      echo build --remote_cache=$$CI_BAZEL_REMOTE_CACHE --google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json > ci.bazelrc
       # Bazel handles the C++ toolchain
-      bazel build @llvm_toolchain//:clang-format --remote_cache=$$CI_BAZEL_REMOTE_CACHE --google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json
+      bazel build @llvm_toolchain//:clang-format
 
       ./tools/reformat.sh
       if ! git diff --quiet; then
@@ -25,7 +27,7 @@ steps:
         exit 1
       fi
 
-      bazel build //... --config=ci --remote_cache=$$CI_BAZEL_REMOTE_CACHE --google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json
+      bazel build //... --config=ci
 
       # Don't use //... as that will also try to update snapshots
-      bazel test //test --test_output=errors --config=ci --remote_cache=$$CI_BAZEL_REMOTE_CACHE --google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json
+      bazel test //test --test_output=errors --config=ci

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 # clangd
 /.cache
 /compile_commands.json
+
+/ci.bazelrc


### PR DESCRIPTION
This means we can set the extra flags related to credentials
once, instead of setting them in multiple places