### PR TITLE
build: Track Buildifier using Bazel

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,15 +7,7 @@ steps:
       CI_BAZEL_REMOTE_CACHE: "https://storage.googleapis.com/sourcegraph_bazel_cache"
     key: build
     command: |
-      # Keep this link in sync with Development.md
-      wget -L https://github.com/bazelbuild/buildtools/releases/download/6.0.0/buildifier-linux-amd64 -O buildifier
-      chmod +x buildifier
-      mv buildifier /usr/local/bin/
-
-
       echo build --remote_cache=$$CI_BAZEL_REMOTE_CACHE --google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json > ci.bazelrc
-      # Bazel handles the C++ toolchain
-      bazel build @llvm_toolchain//:clang-format
 
       ./tools/reformat.sh
       if ! git diff --quiet; then

--- a/Development.md
+++ b/Development.md
@@ -18,11 +18,9 @@
 
 1. [Bazelisk](https://github.com/bazelbuild/bazelisk): This handles Bazel versions
    transparently.
-2. [Buildifier](https://github.com/bazelbuild/buildtools/releases/tag/6.0.0)
-   for formatting Starlark files.
-   <!-- Keep this link in sync with .buildkite/pipeline.yaml -->
 
-Bazel manages the C++ toolchain, so it doesn't need to be downloaded separately.
+Bazel manages the C++ toolchain and other tool dependencies like formatters,
+so they don't need to be downloaded separately.
 (For unclear reasons, Bazel still requires
 a host toolchain to be present for configuring _something_
 but it will not be used for building the code in this project.)

--- a/config/BUILD
+++ b/config/BUILD
@@ -1,0 +1,23 @@
+config_setting(
+    name = "darwin_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)

--- a/fetch_deps.bzl
+++ b/fetch_deps.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 _BAZEL_SKYLIB_VERSION = "1.3.0"
 _PLATFORMS_COMMIT = "3fbc687756043fb58a407c2ea8c944bc2fe1d922"  # 2022 Nov 10
@@ -157,4 +157,25 @@ def fetch_direct_dependencies():
         build_file = "@scip_clang//third_party:dtl.BUILD",
         strip_prefix = "dtl-%s" % _DTL_VERSION,
         urls = ["https://github.com/cubicdaiya/dtl/archive/v%s.tar.gz" % _DTL_VERSION],
+    )
+
+    http_file(
+        name = "buildifier_darwin_arm64",
+        executable = True,
+        sha256 = "21fa0d48ef0b7251eb6e3521cbe25d1e52404763cd2a43aa29f69b5380559dd1",
+        urls = ["https://github.com/bazelbuild/buildtools/releases/download/6.0.0/buildifier-darwin-arm64"],
+    )
+
+    http_file(
+        name = "buildifier_linux_amd64",
+        executable = True,
+        sha256 = "7ff82176879c0c13bc682b6b0e482d670fbe13bbb20e07915edb0ad11be50502",
+        urls = ["https://github.com/bazelbuild/buildtools/releases/download/6.0.0/buildifier-linux-amd64"],
+    )
+
+    http_file(
+        name = "buildifier_linux_arm64",
+        executable = True,
+        sha256 = "9ffa62ea1f55f420c36eeef1427f71a34a5d24332cb861753b2b59c66d6343e2",
+        urls = ["https://github.com/bazelbuild/buildtools/releases/download/6.0.0/buildifier-linux-arm64"],
     )

--- a/third_party/bazel_buildtools/BUILD
+++ b/third_party/bazel_buildtools/BUILD
@@ -1,0 +1,14 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+
+copy_file(
+    name = "buildifier_exe",
+    src = select({
+        "//config:darwin_arm64": "@buildifier_darwin_arm64//file",
+        "//config:linux_x86_64": "@buildifier_linux_amd64//file",
+        "//config:linux_arm64": "@buildifier_linux_arm64//file",
+    }),
+    out = "buildifier",
+    allow_symlink = True,
+    is_executable = True,
+    visibility = ["//tools:__subpackages__"],
+)

--- a/tools/reformat.sh
+++ b/tools/reformat.sh
@@ -4,12 +4,15 @@ set -euo pipefail
 PROJECT_ROOT="$(dirname "${BASH_SOURCE[0]}")/.."
 
 if [ ! -f "bazel-bin/external/llvm_toolchain/clang-format" ]; then
-  echo "Missing clang-format binary; run 'bazel build @llvm_toolchain//:clang-format <args>' first" 1>&2
-  exit 1
+  bazel build @llvm_toolchain//:clang-format
+fi
+
+if [ ! -f "bazel-bin/third_party/bazel_buildtools/buildifier" ]; then
+  bazel build //third_party/bazel_buildtools:buildifier
 fi
 
 (
   cd "$PROJECT_ROOT"
-  git ls-files BUILD WORKSPACE "**/BUILD" "**/.BUILD" "**.bzl" | xargs buildifier
+  git ls-files BUILD WORKSPACE "**/BUILD" "**/.BUILD" "**.bzl" | xargs bazel-bin/third_party/bazel_buildtools/buildifier
   git ls-files "**.cc" "**.h" | xargs bazel-bin/external/llvm_toolchain/clang-format -i
 )


### PR DESCRIPTION
Previously, we were not tracking the buildifier version in Bazel.
Also, the CI was moving the buildifier binary to /usr/local/bin for convenience.
Since @jhchabran pointed out that we may move to stateful agents
in the future, this change removes the /usr/local/bin hack,
and tracks the buildifier version using Bazel itself.

One of the things PR #83 does is that it removes the `git diff` check altogether.
However, that's not correct, because that will skip the formatting check
for C++ and Starlark files. Ideally, I'd like to have two different variations
of that "command", one for checking (in CI), and one for fixing (in local dev).

However, PR #83 only adds support for the checking for Python.

So for simplicity, I've left the `git diff` check in here for now.
If it is still problematic, we can remove it if we can figure out a way
of running all formatters in both check and fix modes.