### PR TITLE
fix: Explicitly flush compilation database

### DIFF
--- a/tools/reduce.py
+++ b/tools/reduce.py
@@ -282,6 +282,7 @@ def default_main():
             mode="w", prefix="compile_commands-", suffix=".json", dir=project_root
         ) as temp_compdb:
             json.dump([new_entry.to_dict()], temp_compdb)
+            temp_compdb.flush()
             minimize_preprocessed = check_scip_clang_output(
                 scip_clang, temp_compdb.name, pattern
             )


### PR DESCRIPTION
There is a read from a separate process later, so we need
to flush to reliably observe the write.
