### PR TITLE
fix: Fix incorrect usages of getPresumedLoc().getFileID()

### DIFF
--- a/indexer/Indexer.cc
+++ b/indexer/Indexer.cc
@@ -135,14 +135,12 @@ void MacroIndexer::saveNonFileBasedMacro(const clang::MacroInfo *macroInfo) {
 void MacroIndexer::saveDefinition(const clang::Token &macroNameToken,
                                   const clang::MacroInfo *macroInfo) {
   ENFORCE(macroInfo);
-  auto startPLoc =
-      this->sourceManager->getPresumedLoc(macroInfo->getDefinitionLoc());
-  ENFORCE(startPLoc.isValid());
-  if (startPLoc.getFileID().isInvalid()) {
+  auto fileId = this->sourceManager->getFileID(macroInfo->getDefinitionLoc());
+  if (fileId.isInvalid()) {
     this->saveNonFileBasedMacro(macroInfo);
     return;
   }
-  this->saveOccurrence(startPLoc.getFileID(), macroNameToken, macroInfo,
+  this->saveOccurrence(fileId, macroNameToken, macroInfo,
                        Role::Definition);
 }
 

--- a/indexer/Indexer.cc
+++ b/indexer/Indexer.cc
@@ -140,8 +140,7 @@ void MacroIndexer::saveDefinition(const clang::Token &macroNameToken,
     this->saveNonFileBasedMacro(macroInfo);
     return;
   }
-  this->saveOccurrence(fileId, macroNameToken, macroInfo,
-                       Role::Definition);
+  this->saveOccurrence(fileId, macroNameToken, macroInfo, Role::Definition);
 }
 
 void MacroIndexer::saveReference(

--- a/indexer/Indexer.cc
+++ b/indexer/Indexer.cc
@@ -171,9 +171,7 @@ void MacroIndexer::saveReference(
   if (refLoc.isMacroID()) {
     refLoc = sourceManager->getSpellingLoc(refLoc);
   }
-  auto refPLoc = this->sourceManager->getPresumedLoc(refLoc);
-  ENFORCE(refPLoc.isValid());
-  auto refFileId = refPLoc.getFileID();
+  auto refFileId = this->sourceManager->getFileID(refLoc);
   // Don't emit references from built-ins to other built-ins
   if (refFileId.isInvalid()) {
     // See NOTE(ref: macro-definition): This reference must be present in

--- a/indexer/SymbolFormatter.cc
+++ b/indexer/SymbolFormatter.cc
@@ -20,7 +20,11 @@ std::string_view SymbolFormatter::getMacroSymbol(clang::SourceLocation defLoc) {
   if (it != this->locationBasedCache.end()) {
     return std::string_view(it->second);
   }
-  auto defPLoc = this->sourceManager.getPresumedLoc(defLoc);
+  // Ignore line directives here because we care about the identity
+  // of the macro (based on the containing file), not where it
+  // originated from.
+  auto defPLoc =
+      this->sourceManager.getPresumedLoc(defLoc, /*UseLineDirectives*/ false);
   ENFORCE(defPLoc.isValid());
   std::string_view filename;
   if (auto optRelPath = this->getCanonicalPath(defPLoc.getFileID())) {

--- a/test/index/macros/system_header.h
+++ b/test/index/macros/system_header.h
@@ -1,3 +1,5 @@
 #pragma GCC system_header
 
 #define SYSTEM_INT 0
+
+#define OTHER_SYSTEM_INT (SYSTEM_INT + 1)

--- a/test/index/macros/system_header.h
+++ b/test/index/macros/system_header.h
@@ -1,0 +1,3 @@
+#pragma GCC system_header
+
+#define SYSTEM_INT 0

--- a/test/index/macros/system_header.snapshot.h
+++ b/test/index/macros/system_header.snapshot.h
@@ -2,3 +2,6 @@
   
   #define SYSTEM_INT 0
 //        ^^^^^^^^^^ definition [..] system_header.h:3:9#
+  
+  #define OTHER_SYSTEM_INT (SYSTEM_INT + 1)
+//        ^^^^^^^^^^^^^^^^ definition [..] system_header.h:5:9#

--- a/test/index/macros/system_header.snapshot.h
+++ b/test/index/macros/system_header.snapshot.h
@@ -1,0 +1,3 @@
+  #pragma GCC system_header
+  
+  #define SYSTEM_INT 0

--- a/test/index/macros/system_header.snapshot.h
+++ b/test/index/macros/system_header.snapshot.h
@@ -5,3 +5,4 @@
   
   #define OTHER_SYSTEM_INT (SYSTEM_INT + 1)
 //        ^^^^^^^^^^^^^^^^ definition [..] system_header.h:5:9#
+//                          ^^^^^^^^^^ reference [..] system_header.h:3:9#

--- a/test/index/macros/system_header.snapshot.h
+++ b/test/index/macros/system_header.snapshot.h
@@ -1,3 +1,4 @@
   #pragma GCC system_header
   
   #define SYSTEM_INT 0
+//        ^^^^^^^^^^ definition [..] system_header.h:3:9#

--- a/test/index/macros/use_system_header.cc
+++ b/test/index/macros/use_system_header.cc
@@ -1,3 +1,3 @@
 #include "system_header.h"
 
-const int system_int = SYSTEM_INT;
+const int total = SYSTEM_INT + OTHER_SYSTEM_INT;

--- a/test/index/macros/use_system_header.cc
+++ b/test/index/macros/use_system_header.cc
@@ -1,0 +1,3 @@
+#include "system_header.h"
+
+const int system_int = SYSTEM_INT;

--- a/test/index/macros/use_system_header.snapshot.cc
+++ b/test/index/macros/use_system_header.snapshot.cc
@@ -1,4 +1,4 @@
   #include "system_header.h"
   
   const int system_int = SYSTEM_INT;
-//                       ^^^^^^^^^^ reference [..] ./system_header.h:3:9#
+//                       ^^^^^^^^^^ reference [..] system_header.h:3:9#

--- a/test/index/macros/use_system_header.snapshot.cc
+++ b/test/index/macros/use_system_header.snapshot.cc
@@ -1,4 +1,5 @@
   #include "system_header.h"
   
-  const int system_int = SYSTEM_INT;
-//                       ^^^^^^^^^^ reference [..] system_header.h:3:9#
+  const int total = SYSTEM_INT + OTHER_SYSTEM_INT;
+//                  ^^^^^^^^^^ reference [..] system_header.h:3:9#
+//                               ^^^^^^^^^^^^^^^^ reference [..] system_header.h:5:9#

--- a/test/index/macros/use_system_header.snapshot.cc
+++ b/test/index/macros/use_system_header.snapshot.cc
@@ -1,0 +1,4 @@
+  #include "system_header.h"
+  
+  const int system_int = SYSTEM_INT;
+//                       ^^^^^^^^^^ reference [..] ./system_header.h:3:9#

--- a/test/index/namespaces/namespaces.cc
+++ b/test/index/namespaces/namespaces.cc
@@ -1,5 +1,7 @@
 // extra-args: -std=c++20
 
+#include "system_header.h"
+
 namespace a {
 }
 

--- a/test/index/namespaces/namespaces.snapshot.cc
+++ b/test/index/namespaces/namespaces.snapshot.cc
@@ -1,5 +1,7 @@
   // extra-args: -std=c++20
   
+  #include "system_header.h"
+  
   namespace a {
 //          ^ definition [..] a/
   }
@@ -42,24 +44,24 @@
   using C = c::C;
   
   #define EXPAND_TO_NAMESPACE \
-//        ^^^^^^^^^^^^^^^^^^^ definition [..] namespaces.cc:34:9#
+//        ^^^^^^^^^^^^^^^^^^^ definition [..] namespaces.cc:36:9#
     namespace from_macro {}
 //            ^^^^^^^^^^ definition [..] from_macro/
 //            ^^^^^^^^^^ definition [..] from_macro/
   
   EXPAND_TO_NAMESPACE
-//^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:34:9#
+//^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:36:9#
   
   #define EXPAND_TO_NAMESPACE_2 EXPAND_TO_NAMESPACE
-//        ^^^^^^^^^^^^^^^^^^^^^ definition [..] namespaces.cc:39:9#
-//                              ^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:34:9#
+//        ^^^^^^^^^^^^^^^^^^^^^ definition [..] namespaces.cc:41:9#
+//                              ^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:36:9#
   
   EXPAND_TO_NAMESPACE_2
-//^^^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:39:9#
+//^^^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:41:9#
   
   #define IDENTITY(x) x
-//        ^^^^^^^^ definition [..] namespaces.cc:43:9#
+//        ^^^^^^^^ definition [..] namespaces.cc:45:9#
   
   IDENTITY(namespace in_macro { })
-//^^^^^^^^ reference [..] namespaces.cc:43:9#
+//^^^^^^^^ reference [..] namespaces.cc:45:9#
 //                   ^^^^^^^^ definition [..] in_macro/

--- a/test/index/namespaces/system_header.h
+++ b/test/index/namespaces/system_header.h
@@ -1,0 +1,3 @@
+#pragma GCC system_header
+
+namespace mystd {}

--- a/test/index/namespaces/system_header.snapshot.h
+++ b/test/index/namespaces/system_header.snapshot.h
@@ -1,0 +1,3 @@
+  #pragma GCC system_header
+  
+  namespace mystd {}

--- a/test/index/namespaces/system_header.snapshot.h
+++ b/test/index/namespaces/system_header.snapshot.h
@@ -1,3 +1,4 @@
   #pragma GCC system_header
   
   namespace mystd {}
+//          ^^^^^ definition [..] mystd/


### PR DESCRIPTION
This PR is meant for commit-by-commit review, so you
can see the effect of each fix on a test.

If more changes are needed, I'll add them by pushing
instead of force-pushing.

This is the planned follow-up to #91 where I flag how
using `getPresumedLoc(loc).getFileID()` can give wrong results.