### PR TITLE
fix: Unique macro occurrences early

### DIFF
--- a/test/index/macros/macros.cc
+++ b/test/index/macros/macros.cc
@@ -36,4 +36,5 @@ int c = IDENTITY_MACRO(10);
 #define MACRO_USING_MACRO \
   IDENTITY_MACRO(0)
 
-int d = MACRO_USING_MACRO;
+// two uses of a macro that expands to another macro
+int d = MACRO_USING_MACRO + MACRO_USING_MACRO;

--- a/test/index/macros/macros.snapshot.cc
+++ b/test/index/macros/macros.snapshot.cc
@@ -51,5 +51,7 @@
     IDENTITY_MACRO(0)
 //  ^^^^^^^^^^^^^^ reference [..] macros.cc:32:9#
   
-  int d = MACRO_USING_MACRO;
+  // two uses of a macro that expands to another macro
+  int d = MACRO_USING_MACRO + MACRO_USING_MACRO;
 //        ^^^^^^^^^^^^^^^^^ reference [..] macros.cc:36:9#
+//                            ^^^^^^^^^^^^^^^^^ reference [..] macros.cc:36:9#


### PR DESCRIPTION
Without it, an existing "is unique" assertion to fire, because we incorrectly
assumed that we'd only emit an occurrence once.