### PR TITLE
feat: Emit refs for declaration references

### DIFF
--- a/indexer/Indexer.cc
+++ b/indexer/Indexer.cc
@@ -369,8 +369,11 @@ void TuIndexer::saveNestedNameSpecifier(
       return;
     }
     scip::Occurrence occ;
-    auto [range, fileId] = FileLocalSourceRange::fromNonEmpty(
-        this->sourceManager, nameSpecLoc.getLocalSourceRange());
+    // Don't use nameSpecLoc.getLocalSourceRange() as that may give
+    // two MacroID SourceLocations, in case the NestedNameSpecifier
+    // arises from a macro expansion.
+    auto [range, fileId] =
+        this->getTokenExpansionRange(nameSpecLoc.getLocalBeginLoc());
     range.addToOccurrence(occ);
     std::string_view symbol = optSymbol.value();
     occ.set_symbol(symbol.data(), symbol.size());

--- a/indexer/Indexer.h
+++ b/indexer/Indexer.h
@@ -20,11 +20,14 @@
 #include "indexer/SymbolFormatter.h"
 
 namespace clang {
+class ASTContext;
 class Decl;
+class DeclRefExpr;
 class EnumConstantDecl;
 class EnumDecl;
 class MacroDefinition;
 class NamespaceDecl;
+class NestedNameSpecifier;
 class MacroInfo;
 class SourceManager;
 class Token;
@@ -179,18 +182,20 @@ struct PartialDocument {
 class TuIndexer final {
   const clang::SourceManager &sourceManager;
   const clang::LangOptions &langOptions;
+  [[maybe_unused]] const clang::ASTContext &astContext;
   SymbolFormatter &symbolFormatter;
   absl::flat_hash_map<LlvmToAbslHashAdapter<clang::FileID>, PartialDocument>
       documentMap;
 
 public:
   TuIndexer(const clang::SourceManager &, const clang::LangOptions &,
-            SymbolFormatter &);
+            const clang::ASTContext &, SymbolFormatter &);
 
   // See NOTE(ref: emit-vs-save) for naming conventions.
   void saveEnumConstantDecl(const clang::EnumConstantDecl *);
   void saveEnumDecl(const clang::EnumDecl *);
   void saveNamespaceDecl(const clang::NamespaceDecl *);
+  void saveDeclRefExpr(const clang::DeclRefExpr *);
 
   void emitDocumentOccurrencesAndSymbols(bool deterministic, clang::FileID,
                                          scip::Document &);
@@ -198,6 +203,8 @@ public:
 private:
   std::pair<FileLocalSourceRange, clang::FileID>
   getTokenExpansionRange(clang::SourceLocation startLoc) const;
+
+  void saveNestedNameSpecifier(const clang::NestedNameSpecifierLoc &);
 
   void tryGetDocComment(const clang::Decl *,
                         llvm::SmallVectorImpl<std::string> &) const;

--- a/indexer/SymbolFormatter.cc
+++ b/indexer/SymbolFormatter.cc
@@ -221,6 +221,20 @@ SymbolFormatter::getEnumSymbol(const clang::EnumDecl *enumDecl) {
 }
 
 std::optional<std::string_view>
+SymbolFormatter::getNamedDeclSymbol(const clang::NamedDecl *namedDecl) {
+#define HANDLE(kind_)            \
+  case clang::Decl::Kind::kind_: \
+    return this->get##kind_##Symbol(llvm::cast<clang::kind_##Decl>(namedDecl));
+  switch (namedDecl->getKind()) {
+    HANDLE(Enum)
+    HANDLE(EnumConstant)
+    HANDLE(Namespace)
+  default:
+    return {};
+  }
+}
+
+std::optional<std::string_view>
 SymbolFormatter::getNamespaceSymbol(const clang::NamespaceDecl *namespaceDecl) {
   return this->getSymbolCached(
       namespaceDecl, [&]() -> std::optional<std::string> {

--- a/indexer/SymbolFormatter.h
+++ b/indexer/SymbolFormatter.h
@@ -19,6 +19,7 @@ class Decl;
 class DeclContext;
 class EnumConstantDecl;
 class EnumDecl;
+class NamedDecl;
 class NamespaceDecl;
 class TagDecl;
 } // namespace clang
@@ -56,6 +57,8 @@ public:
   getEnumConstantSymbol(const clang::EnumConstantDecl *);
 
   std::optional<std::string_view> getEnumSymbol(const clang::EnumDecl *);
+
+  std::optional<std::string_view> getNamedDeclSymbol(const clang::NamedDecl *);
 
   /// Returns nullopt for anonymous namespaces in files for which
   /// getCanonicalPath returns nullopt.

--- a/indexer/Worker.cc
+++ b/indexer/Worker.cc
@@ -689,6 +689,11 @@ public:
     return true;
   }
 
+  bool VisitDeclRefExpr(clang::DeclRefExpr *declRefExpr) {
+    this->tuIndexer.saveDeclRefExpr(declRefExpr);
+    return true;
+  }
+
   void writeIndex(SymbolFormatter &&symbolFormatter, MacroIndexer &&macroIndex,
                   scip::Index &scipIndex) {
     std::vector<std::pair<RootRelativePathRef, clang::FileID>> relativePaths;
@@ -794,7 +799,7 @@ public:
     };
     SymbolFormatter symbolFormatter{sourceManager, getRelativePath};
     TuIndexer tuIndexer{sourceManager, this->sema->getLangOpts(),
-                        symbolFormatter};
+                        this->sema->getASTContext(), symbolFormatter};
 
     IndexerAstVisitor visitor{canonicalPathMap, std::move(toBeIndexed),
                               this->options.deterministic, tuIndexer};

--- a/test/index/namespaces/namespaces.cc
+++ b/test/index/namespaces/namespaces.cc
@@ -45,3 +45,15 @@ EXPAND_TO_NAMESPACE_2
 #define IDENTITY(x) x
 
 IDENTITY(namespace in_macro { })
+
+namespace a {
+  namespace c {
+    enum E { E0 };
+  }
+  namespace c_alias = c;
+}
+
+void f(a::c_alias::E) {
+  (void)a::c::E::E0;
+  (void)a::c_alias::E::E0;
+}

--- a/test/index/namespaces/namespaces.snapshot.cc
+++ b/test/index/namespaces/namespaces.snapshot.cc
@@ -65,3 +65,26 @@
   IDENTITY(namespace in_macro { })
 //^^^^^^^^ definition [..] in_macro/
 //^^^^^^^^ reference [..] namespaces.cc:45:9#
+  
+  namespace a {
+//          ^ definition [..] a/
+    namespace c {
+//            ^ definition [..] a/c/
+      enum E { E0 };
+//         ^ definition [..] a/c/E#
+//             ^^ definition [..] a/c/E0.
+    }
+    namespace c_alias = c;
+  }
+  
+  void f(a::c_alias::E) {
+    (void)a::c::E::E0;
+//        ^ reference [..] a/
+//           ^ reference [..] a/c/
+//              ^ reference [..] a/c/E#
+//                 ^^ reference [..] a/c/E0.
+    (void)a::c_alias::E::E0;
+//        ^ reference [..] a/
+//                    ^ reference [..] a/c/E#
+//                       ^^ reference [..] a/c/E0.
+  }

--- a/test/index/types/types.cc
+++ b/test/index/types/types.cc
@@ -87,4 +87,7 @@ enum class E { E0 };
 void f(GenericClass<E, int(E::E0)>) {
   (void)E::E0;
   (void)::E::E0;
+#define QUALIFIED(enum_name, case_name) enum_name::case_name;
+  (void)QUALIFIED(E, E0);
+#undef QUALIFIED
 }

--- a/test/index/types/types.cc
+++ b/test/index/types/types.cc
@@ -78,3 +78,13 @@ enum class PartiallyDocumented {
   Documented,
   Undocumented,
 };
+
+template <typename T, int N>
+class GenericClass {};
+
+enum class E { E0 };
+
+void f(GenericClass<E, int(E::E0)>) {
+  (void)E::E0;
+  (void)::E::E0;
+}

--- a/test/index/types/types.snapshot.cc
+++ b/test/index/types/types.snapshot.cc
@@ -37,6 +37,7 @@
 //  ^^^ definition [..] EC#EC1.
 //  documentation
 //  | And a moo-moo there
+//        ^^^ reference [..] EC#EC0.
   };
   
   namespace a {
@@ -61,7 +62,9 @@
 //    ^^ definition [..] has_anon_enum/F2.
 //    documentation
 //    | Everywhere a moo-moo 
+//         ^^ reference [..] has_anon_enum/E2.
     } f = F1;
+//        ^^ reference [..] has_anon_enum/F1.
   }
   
   class F0;
@@ -75,6 +78,7 @@
     enum { ANON2 = ANON1 } anon2;
 //  ^^^^ definition [..] F1#$anontype_3#
 //         ^^^^^ definition [..] F1#ANON2.
+//                 ^^^^^ reference [..] F1#ANON1.
   };
   
   class F0 {
@@ -113,3 +117,21 @@
     Undocumented,
 //  ^^^^^^^^^^^^ definition [..] PartiallyDocumented#Undocumented.
   };
+  
+  template <typename T, int N>
+  class GenericClass {};
+  
+  enum class E { E0 };
+//           ^ definition [..] E#
+//               ^^ definition [..] E#E0.
+  
+  void f(GenericClass<E, int(E::E0)>) {
+//                           ^ reference [..] E#
+//                              ^^ reference [..] E#E0.
+    (void)E::E0;
+//        ^ reference [..] E#
+//           ^^ reference [..] E#E0.
+    (void)::E::E0;
+//          ^ reference [..] E#
+//             ^^ reference [..] E#E0.
+  }

--- a/test/index/types/types.snapshot.cc
+++ b/test/index/types/types.snapshot.cc
@@ -134,4 +134,12 @@
     (void)::E::E0;
 //          ^ reference [..] E#
 //             ^^ reference [..] E#E0.
+  #define QUALIFIED(enum_name, case_name) enum_name::case_name;
+//        ^^^^^^^^^ definition [..] types.cc:90:9#
+    (void)QUALIFIED(E, E0);
+//        ^^^^^^^^^ reference [..] E#
+//        ^^^^^^^^^ reference [..] E#E0.
+//        ^^^^^^^^^ reference [..] types.cc:90:9#
+  #undef QUALIFIED
+//       ^^^^^^^^^ reference [..] types.cc:90:9#
   }

--- a/test/index/types/types.snapshot.h
+++ b/test/index/types/types.snapshot.h
@@ -5,4 +5,5 @@
 //  ^^^^ definition [..] has_anon_enum/$anontype_a58c49fe3a7ec9aa_0#
 //         ^^ definition [..] has_anon_enum/E1.
 //             ^^ definition [..] has_anon_enum/E2.
+//                      ^^ reference [..] has_anon_enum/E1.
   }


### PR DESCRIPTION
TODO:
- [x] Add test cases involving
  - [x] Declaration references in other parts of the AST (e.g. in non-constant expression positions, template parameters, non-type template parameters)
  - [x] Qualified references `A::B::C`
  - [x] Root-qualified references `::a::b`
  - [x] Namespace aliases in the chain (so that we skip intermediate stuff)
- [x] File issues for some TODOs for different cases and link them
- [x] File issue for enum doc comments/fix that
- [x] Needs integration testing (I should maybe pick 1-2 simple projects and have this run in CI...)