### PR TITLE
fix: Fix non-determinism in occurrence ordering

### DIFF
--- a/indexer/ScipExtras.h
+++ b/indexer/ScipExtras.h
@@ -20,6 +20,9 @@
 
 namespace scip {
 
+std::strong_ordering compareRelationships(const scip::Relationship &lhs,
+                                          const scip::Relationship &rhs);
+
 struct RelationshipExt {
   scip::Relationship rel;
 
@@ -35,6 +38,13 @@ struct RelationshipExt {
                       r.is_implementation());
   }
 };
+
+std::strong_ordering
+compareScipRange(const google::protobuf::RepeatedField<int32_t> &lhs,
+                 const google::protobuf::RepeatedField<int32_t> &rhs);
+
+std::strong_ordering compareOccurrences(const scip::Occurrence &lhs,
+                                        const scip::Occurrence &rhs);
 
 struct OccurrenceExt {
   scip::Occurrence occ;

--- a/test/index/namespaces/namespaces.snapshot.cc
+++ b/test/index/namespaces/namespaces.snapshot.cc
@@ -48,20 +48,20 @@
     namespace from_macro {}
   
   EXPAND_TO_NAMESPACE
-//^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:36:9#
 //^^^^^^^^^^^^^^^^^^^ definition [..] from_macro/
+//^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:36:9#
   
   #define EXPAND_TO_NAMESPACE_2 EXPAND_TO_NAMESPACE
 //        ^^^^^^^^^^^^^^^^^^^^^ definition [..] namespaces.cc:41:9#
 //                              ^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:36:9#
   
   EXPAND_TO_NAMESPACE_2
-//^^^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:41:9#
 //^^^^^^^^^^^^^^^^^^^^^ definition [..] from_macro/
+//^^^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:41:9#
   
   #define IDENTITY(x) x
 //        ^^^^^^^^ definition [..] namespaces.cc:45:9#
   
   IDENTITY(namespace in_macro { })
-//^^^^^^^^ reference [..] namespaces.cc:45:9#
 //^^^^^^^^ definition [..] in_macro/
+//^^^^^^^^ reference [..] namespaces.cc:45:9#

--- a/test/index/types/types.snapshot.cc
+++ b/test/index/types/types.snapshot.cc
@@ -98,6 +98,6 @@
 //     ^^^^^ reference [..] types.cc:69:9#
 //     ^^^^^ definition [..] VisitSightseeing#
     VISIT(Museum),
-//  ^^^^^ reference [..] types.cc:69:9#
 //  ^^^^^ definition [..] VisitMuseum.
+//  ^^^^^ reference [..] types.cc:69:9#
   };


### PR DESCRIPTION
This was causing snapshot comparisons to randomly fail.

Verified the fix by running:

```
bazel test //test:test_index --spawn_strategy=local --config=dev --test_output=errors --cache_test_results=no --runs_per_test=10 --jobs 1
```

The `--jobs 1` seems to be needed as concurrently running
multiple instances of a test overwrites the same temporary file.

Fixes #99