### PR TITLE
refactor: Consolidate symbol formatting code

### DIFF
--- a/indexer/Hash.h
+++ b/indexer/Hash.h
@@ -2,6 +2,7 @@
 #define SCIP_CLANG_HASH_H
 
 #include <cstdint>
+#include <string_view>
 #include <utility>
 
 #include "absl/hash/hash.h"
@@ -17,6 +18,12 @@ struct HashValue {
   void mix(const uint8_t *key, size_t data) {
     this->rawValue = wyhash(key, data, this->rawValue, /*default secret*/ _wyp);
   };
+
+  static uint64_t forText(std::string_view text) {
+    HashValue v{0};
+    v.mix(reinterpret_cast<const uint8_t *>(text.data()), text.size());
+    return v.rawValue;
+  }
 
   DERIVE_HASH_1(HashValue, self.rawValue)
   DERIVE_CMP_ALL(HashValue)

--- a/indexer/SymbolFormatter.cc
+++ b/indexer/SymbolFormatter.cc
@@ -35,7 +35,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, Escaped s) {
         || c == '_') {
       continue;
     }
-    needsBacktickEscape = c == '`';
+    needsBacktickEscape |= c == '`';
     needsEscape = true;
   }
   if (needsEscape) {

--- a/indexer/SymbolFormatter.cc
+++ b/indexer/SymbolFormatter.cc
@@ -3,18 +3,122 @@
 #include <string_view>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
 
 #include "clang/AST/Decl.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "scip/scip.pb.h"
 
 #include "indexer/Enforce.h"
 #include "indexer/Hash.h"
 #include "indexer/LlvmAdapter.h"
 #include "indexer/SymbolFormatter.h"
 
+namespace {
+struct Escaped {
+  std::string_view text;
+};
+} // namespace
+
+namespace llvm {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, Escaped s) {
+  bool needsEscape = false;
+  bool needsBacktickEscape = false;
+  for (auto &c : s.text) {
+    if (('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+        || ('0' <= c && c <= '9') || c == '+' || c == '-' || c == '$'
+        || c == '_') {
+      continue;
+    }
+    needsBacktickEscape = c == '`';
+    needsEscape = true;
+  }
+  if (needsEscape) {
+    if (needsBacktickEscape) {
+      return os << '`' << absl::StrReplaceAll(s.text, {{"`", "``"}}) << '`';
+    }
+    return os << '`' << s.text << '`';
+  }
+  return os << s.text;
+}
+} // namespace llvm
+
+static void addSpaceEscaped(llvm::raw_ostream &out, std::string_view in) {
+  if (absl::StrContains(in, ' ')) {
+    out << absl::StrReplaceAll(in, {{" ", "  "}});
+    return;
+  }
+  out << in;
+}
+
 namespace scip_clang {
+
+void DescriptorBuilder::formatTo(llvm::raw_ostream &out) const {
+  // See https://github.com/sourcegraph/scip/blob/main/scip.proto#L104-L125
+  switch (this->suffix) {
+  case scip::Descriptor::Namespace:
+    out << ::Escaped{this->name} << '/';
+    break;
+  case scip::Descriptor::Type:
+    out << ::Escaped{this->name} << '#';
+    break;
+  case scip::Descriptor::Term:
+    out << ::Escaped{this->name} << '.';
+    break;
+  case scip::Descriptor::Meta:
+    out << ::Escaped{this->name} << ':';
+    break;
+  case scip::Descriptor::Method:
+    out << ::Escaped{this->name} << '(' << ::Escaped{this->disambiguator}
+        << ").";
+    break;
+  case scip::Descriptor::TypeParameter:
+    out << '[' << ::Escaped{this->name} << ']';
+    break;
+  case scip::Descriptor::Parameter:
+    out << '(' << ::Escaped{this->name} << ')';
+    break;
+  case scip::Descriptor::Macro:
+    out << ::Escaped{this->name} << '!';
+    break;
+  default:
+    ENFORCE(false, "unknown descriptor suffix %s",
+            scip::Descriptor::Suffix_Name(this->suffix));
+  }
+}
+
+void SymbolBuilder::formatTo(std::string &buf) const {
+  llvm::raw_string_ostream out(buf);
+  out << "cxx . "; // scheme manager
+  for (auto text : {this->packageName, this->packageVersion}) {
+    if (text.empty()) {
+      out << ". ";
+      continue;
+    }
+    ::addSpaceEscaped(out, text);
+    out << ' ';
+  }
+  for (auto &descriptor : this->descriptors) {
+    descriptor.formatTo(out);
+  }
+}
+
+std::string
+SymbolBuilder::formatContextual(std::string_view contextSymbol,
+                                const DescriptorBuilder &descriptor) {
+  std::string buffer;
+  buffer.reserve(contextSymbol.size() + descriptor.name.size()
+                 + descriptor.disambiguator.size() + 2);
+  buffer.append(contextSymbol);
+  llvm::raw_string_ostream os(buffer);
+  descriptor.formatTo(os);
+  return buffer;
+}
 
 std::string_view SymbolFormatter::getMacroSymbol(clang::SourceLocation defLoc) {
   auto it = this->locationBasedCache.find({defLoc});
@@ -33,8 +137,18 @@ std::string_view SymbolFormatter::getMacroSymbol(clang::SourceLocation defLoc) {
   } else {
     filename = std::string_view(defPLoc.getFilename());
   }
-  std::string out{fmt::format("c . todo-pkg todo-version {}:{}:{}#", filename,
-                              defPLoc.getLine(), defPLoc.getColumn())};
+
+  // Technically, ':' is used by SCIP for <meta>, but using ':'
+  // here lines up with other situations like compiler errors.
+  auto name = this->formatTemporary("{}:{}:{}", filename, defPLoc.getLine(),
+                                    defPLoc.getColumn());
+  std::string out{};
+  SymbolBuilder{.packageName = "todo-pkg",
+                .packageVersion = "todo-version",
+                .descriptors = {DescriptorBuilder{
+                    .name = name, .suffix = scip::Descriptor::Macro}}}
+      .formatTo(out);
+
   auto [newIt, inserted] =
       this->locationBasedCache.insert({{defLoc}, std::move(out)});
   ENFORCE(inserted, "key was missing earlier, so insert should've succeeded");
@@ -117,7 +231,12 @@ SymbolFormatter::getContextSymbol(const clang::DeclContext *declContext) {
       || llvm::isa<clang::ExternCContextDecl>(declContext)) {
     auto decl = llvm::dyn_cast<clang::Decl>(declContext);
     return this->getSymbolCached(decl, [&]() -> std::optional<std::string> {
-      return "c . todo-pkg todo-version ";
+      this->scratchBuffer.clear();
+      SymbolBuilder{.packageName = "todo-pkg",
+                    .packageVersion = "todo-version",
+                    .descriptors = {}}
+          .formatTo(this->scratchBuffer);
+      return std::string(this->scratchBuffer);
     });
   }
   // TODO: Handle all cases of DeclContext here:
@@ -148,11 +267,10 @@ SymbolFormatter::getTagSymbol(const clang::TagDecl *tagDecl) {
     }
     auto contextSymbol = optContextSymbol.value();
     if (!tagDecl->getDeclName().isEmpty()) {
-      llvm::raw_string_ostream os(this->scratchBuffer);
-      static_cast<const clang::NamedDecl *>(tagDecl)->printName(os);
-      std::string out{fmt::format("{}{}#", contextSymbol, this->scratchBuffer)};
-      this->scratchBuffer.clear();
-      return out;
+      return SymbolBuilder::formatContextual(
+          contextSymbol,
+          DescriptorBuilder{.name = this->formatTemporary(tagDecl),
+                            .suffix = scip::Descriptor::Type});
     }
     auto definitionTagDecl = tagDecl->getDefinition();
     ENFORCE(definitionTagDecl, "can't forward-declare an anonymous type");
@@ -164,6 +282,7 @@ SymbolFormatter::getTagSymbol(const clang::TagDecl *tagDecl) {
     auto counter = this->anonymousTypeCounters[{defFileId}]++;
 
     auto declContext = definitionTagDecl->getDeclContext();
+    DescriptorBuilder descriptor{.name = {}, .suffix = scip::Descriptor::Type};
     if (llvm::isa<clang::NamespaceDecl>(declContext)
         || llvm::isa<clang::TranslationUnitDecl>(declContext)) {
       // If the anonymous type is inside a namespace, then we know the
@@ -180,14 +299,15 @@ SymbolFormatter::getTagSymbol(const clang::TagDecl *tagDecl) {
       // If we don't include the hash, the anonymous structs will end up with
       // the same symbol name.
       if (auto optRelativePath = this->getCanonicalPath(defFileId)) {
-        HashValue hashValue{0};
-        auto sv = optRelativePath->asStringView();
-        hashValue.mix(reinterpret_cast<const uint8_t *>(sv.data()), sv.size());
-        return fmt::format("{}$anontype_{:x}_{}#", contextSymbol,
-                           hashValue.rawValue, counter);
+        descriptor.name = this->formatTemporary(
+            "$anonymous_type_{:x}_{}",
+            HashValue::forText(optRelativePath->asStringView()), counter);
       }
     }
-    return fmt::format("{}$anontype_{}#", contextSymbol, counter);
+    if (descriptor.name.empty()) {
+      descriptor.name = this->formatTemporary("$anonymous_type_{}", counter);
+    }
+    return SymbolBuilder::formatContextual(contextSymbol, descriptor);
   });
 }
 
@@ -209,9 +329,10 @@ std::optional<std::string_view> SymbolFormatter::getEnumConstantSymbol(
         if (!optContextSymbol.has_value()) {
           return {};
         }
-        std::string out{fmt::format("{}{}.", optContextSymbol.value(),
-                                    toStringView(enumConstantDecl->getName()))};
-        return out;
+        return SymbolBuilder::formatContextual(
+            optContextSymbol.value(),
+            DescriptorBuilder{.name = toStringView(enumConstantDecl->getName()),
+                              .suffix = scip::Descriptor::Term});
       });
 }
 
@@ -238,6 +359,13 @@ std::optional<std::string_view>
 SymbolFormatter::getNamespaceSymbol(const clang::NamespaceDecl *namespaceDecl) {
   return this->getSymbolCached(
       namespaceDecl, [&]() -> std::optional<std::string> {
+        auto optContextSymbol =
+            this->getContextSymbol(namespaceDecl->getDeclContext());
+        if (!optContextSymbol.has_value()) {
+          return {};
+        }
+        auto contextSymbol = optContextSymbol.value();
+        DescriptorBuilder descriptor{.suffix = scip::Descriptor::Namespace};
         if (namespaceDecl->isAnonymousNamespace()) {
           auto mainFileId = this->sourceManager.getMainFileID();
           ENFORCE(mainFileId.isValid());
@@ -256,22 +384,21 @@ SymbolFormatter::getNamespaceSymbol(const clang::NamespaceDecl *namespaceDecl) {
             // are rarely (if ever) used in headers.
             return {};
           }
-          fmt::format_to(std::back_inserter(this->scratchBuffer), "$ANON/{}\0",
-                         path->asStringView());
+          descriptor.name = this->formatTemporary("$anonymous_namespace_{}",
+                                                  path->asStringView());
         } else {
-          llvm::raw_string_ostream os(this->scratchBuffer);
-          namespaceDecl->printQualifiedName(os);
-          // Directly using string replacement is justified because the
-          // DeclContext chain for a NamespaceDecl only contains namespaces or
-          // the main TU. Namespaces cannot be declared inside types, functions
-          // etc.
-          absl::StrReplaceAll({{"::", "/"}}, &this->scratchBuffer);
+          descriptor.name = this->formatTemporary(namespaceDecl);
         }
-        std::string out{
-            fmt::format("c . todo-pkg todo-version {}/", this->scratchBuffer)};
-        this->scratchBuffer.clear();
-        return out;
+        return SymbolBuilder::formatContextual(contextSymbol, descriptor);
       });
+}
+
+std::string_view
+SymbolFormatter::formatTemporary(const clang::NamedDecl *namedDecl) {
+  this->scratchBuffer.clear();
+  llvm::raw_string_ostream os(this->scratchBuffer);
+  namedDecl->printName(os);
+  return std::string_view(this->scratchBuffer);
 }
 
 } // namespace scip_clang

--- a/indexer/SymbolFormatter.cc
+++ b/indexer/SymbolFormatter.cc
@@ -112,8 +112,9 @@ std::string
 SymbolBuilder::formatContextual(std::string_view contextSymbol,
                                 const DescriptorBuilder &descriptor) {
   std::string buffer;
+  auto maxExtraChars = 3; // For methods, we end up adding '(', ')' and '.'
   buffer.reserve(contextSymbol.size() + descriptor.name.size()
-                 + descriptor.disambiguator.size() + 2);
+                 + descriptor.disambiguator.size() + maxExtraChars);
   buffer.append(contextSymbol);
   llvm::raw_string_ostream os(buffer);
   descriptor.formatTo(os);

--- a/indexer/SymbolFormatter.cc
+++ b/indexer/SymbolFormatter.cc
@@ -108,6 +108,7 @@ void SymbolBuilder::formatTo(std::string &buf) const {
   }
 }
 
+// static
 std::string
 SymbolBuilder::formatContextual(std::string_view contextSymbol,
                                 const DescriptorBuilder &descriptor) {

--- a/indexer/SymbolFormatter.h
+++ b/indexer/SymbolFormatter.h
@@ -55,10 +55,21 @@ struct SymbolBuilder {
   std::string_view packageVersion;
   llvm::SmallVector<DescriptorBuilder, 4> descriptors;
 
+  /// Format a symbol string according to the standardized SCIP representation:
+  /// https://github.com/sourcegraph/scip/blob/main/scip.proto#L101-L127
   void formatTo(std::string &) const;
 
+  /// Format the symbol string for an entity, making use of the symbol string
+  /// for its declaration context.
+  ///
+  /// For example, when constructing a symbol string for \c std::string_view,
+  /// \p contextSymbol would be the symbol string for \c std,
+  /// and \p descriptor would describe the \c string_view type.
+  ///
+  /// Since the standard formatting for SCIP symbols is prefix-based,
+  /// this avoids the extra work of recomputing parent symbol strings.
   static std::string formatContextual(std::string_view contextSymbol,
-                                      const DescriptorBuilder &);
+                                      const DescriptorBuilder &descriptor);
 };
 
 class SymbolFormatter final {

--- a/indexer/SymbolFormatter.h
+++ b/indexer/SymbolFormatter.h
@@ -10,9 +10,11 @@
 
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include "indexer/LlvmAdapter.h"
 #include "indexer/Path.h"
+#include "scip/scip.pb.h"
 
 namespace clang {
 class Decl;
@@ -24,10 +26,40 @@ class NamespaceDecl;
 class TagDecl;
 } // namespace clang
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace scip_clang {
 
 using GetCanonicalPath =
     absl::FunctionRef<std::optional<RootRelativePathRef>(clang::FileID)>;
+
+/// Type similar to \c scip::Descriptor but carrying \c string_view fields
+/// instead to avoid redundant intermediate allocations.
+struct DescriptorBuilder {
+  std::string_view name;
+  std::string_view disambiguator;
+  scip::Descriptor::Suffix suffix;
+
+  void formatTo(llvm::raw_ostream &) const;
+};
+
+/// Type similar to \c scip::Symbol but carrying \c string_view fields instead
+/// to avoid redundant allocations.
+///
+/// Meant for transient use in constructing symbol strings, since a
+/// \c scip::Index doesn't store any \c scip::Symbol values directly.
+struct SymbolBuilder {
+  std::string_view packageName;
+  std::string_view packageVersion;
+  llvm::SmallVector<DescriptorBuilder, 4> descriptors;
+
+  void formatTo(std::string &) const;
+
+  static std::string formatContextual(std::string_view contextSymbol,
+                                      const DescriptorBuilder &);
+};
 
 class SymbolFormatter final {
   const clang::SourceManager &sourceManager;
@@ -72,6 +104,18 @@ private:
   std::optional<std::string_view>
   getSymbolCached(const clang::Decl *,
                   absl::FunctionRef<std::optional<std::string>()>);
+
+  /// Format the string to a buffer stored by `this` and return a view to it.
+  template <typename... T>
+  std::string_view formatTemporary(fmt::format_string<T...> fmt, T &&...args) {
+    this->scratchBuffer.clear();
+    fmt::format_to(std::back_inserter(this->scratchBuffer), fmt,
+                   std::forward<T>(args)...);
+    return std::string_view(this->scratchBuffer);
+  }
+
+  /// Format the string to a buffer stored by `this` and return a view to it.
+  std::string_view formatTemporary(const clang::NamedDecl *);
 };
 
 } // namespace scip_clang

--- a/test/Snapshot.cc
+++ b/test/Snapshot.cc
@@ -127,7 +127,7 @@ void formatSnapshot(const scip::Document &document,
   auto formatSymbol = [](const std::string &symbol) -> std::string {
     // Strip out repeating information for cleaner snapshots.
     return absl::StrReplaceAll(symbol, {
-                                           {"c . ", ""}, // indexer prefix
+                                           {"cxx . ", ""}, // indexer prefix
                                            {"todo-pkg todo-version", "[..]"},
                                        });
   };

--- a/test/index/macros/macros.snapshot.cc
+++ b/test/index/macros/macros.snapshot.cc
@@ -3,55 +3,55 @@
   #include "macros.h"
   
   int a = MY_MACRO + MY_MACRO_ALIAS;
-//        ^^^^^^^^ reference [..] macros.h:1:9#
-//                   ^^^^^^^^^^^^^^ reference [..] macros.h:9:9#
+//        ^^^^^^^^ reference [..] `macros.h:1:9`!
+//                   ^^^^^^^^^^^^^^ reference [..] `macros.h:9:9`!
   
   #undef MY_MACRO
-//       ^^^^^^^^ reference [..] macros.h:1:9#
+//       ^^^^^^^^ reference [..] `macros.h:1:9`!
   
   #if defined(MY_MACRO) // no reference
   #endif
   
   #define MY_MACRO 1
-//        ^^^^^^^^ definition [..] macros.cc:12:9#
+//        ^^^^^^^^ definition [..] `macros.cc:12:9`!
   
   int b = MY_MACRO;
-//        ^^^^^^^^ reference [..] macros.cc:12:9#
+//        ^^^^^^^^ reference [..] `macros.cc:12:9`!
   
   #if defined(MY_MACRO)
-//            ^^^^^^^^ reference [..] macros.cc:12:9#
+//            ^^^^^^^^ reference [..] `macros.cc:12:9`!
   #endif
   
   #ifdef MY_MACRO
-//       ^^^^^^^^ reference [..] macros.cc:12:9#
+//       ^^^^^^^^ reference [..] `macros.cc:12:9`!
   #endif
   
   #ifndef MY_MACRO
-//        ^^^^^^^^ reference [..] macros.cc:12:9#
+//        ^^^^^^^^ reference [..] `macros.cc:12:9`!
   #endif
   
   #ifdef NOT_YET_DEFINED_MACRO
   #elifndef MY_MACRO
-//          ^^^^^^^^ reference [..] macros.cc:12:9#
+//          ^^^^^^^^ reference [..] `macros.cc:12:9`!
   #elifdef MY_MACRO
-//         ^^^^^^^^ reference [..] macros.cc:12:9#
+//         ^^^^^^^^ reference [..] `macros.cc:12:9`!
   #endif
   
   #define NOT_YET_DEFINED_MACRO
-//        ^^^^^^^^^^^^^^^^^^^^^ definition [..] macros.cc:30:9#
+//        ^^^^^^^^^^^^^^^^^^^^^ definition [..] `macros.cc:30:9`!
   
   #define IDENTITY_MACRO(__x) __x
-//        ^^^^^^^^^^^^^^ definition [..] macros.cc:32:9#
+//        ^^^^^^^^^^^^^^ definition [..] `macros.cc:32:9`!
   
   int c = IDENTITY_MACRO(10);
-//        ^^^^^^^^^^^^^^ reference [..] macros.cc:32:9#
+//        ^^^^^^^^^^^^^^ reference [..] `macros.cc:32:9`!
   
   #define MACRO_USING_MACRO \
-//        ^^^^^^^^^^^^^^^^^ definition [..] macros.cc:36:9#
+//        ^^^^^^^^^^^^^^^^^ definition [..] `macros.cc:36:9`!
     IDENTITY_MACRO(0)
-//  ^^^^^^^^^^^^^^ reference [..] macros.cc:32:9#
+//  ^^^^^^^^^^^^^^ reference [..] `macros.cc:32:9`!
   
   // two uses of a macro that expands to another macro
   int d = MACRO_USING_MACRO + MACRO_USING_MACRO;
-//        ^^^^^^^^^^^^^^^^^ reference [..] macros.cc:36:9#
-//                            ^^^^^^^^^^^^^^^^^ reference [..] macros.cc:36:9#
+//        ^^^^^^^^^^^^^^^^^ reference [..] `macros.cc:36:9`!
+//                            ^^^^^^^^^^^^^^^^^ reference [..] `macros.cc:36:9`!

--- a/test/index/macros/macros.snapshot.h
+++ b/test/index/macros/macros.snapshot.h
@@ -1,14 +1,14 @@
   #define MY_MACRO 0
-//        ^^^^^^^^ definition [..] macros.h:1:9#
+//        ^^^^^^^^ definition [..] `macros.h:1:9`!
   
   #ifdef MY_MACRO
-//       ^^^^^^^^ reference [..] macros.h:1:9#
+//       ^^^^^^^^ reference [..] `macros.h:1:9`!
   #endif
   
   #ifndef MY_MACRO
-//        ^^^^^^^^ reference [..] macros.h:1:9#
+//        ^^^^^^^^ reference [..] `macros.h:1:9`!
   #endif
   
   #define MY_MACRO_ALIAS MY_MACRO
-//        ^^^^^^^^^^^^^^ definition [..] macros.h:9:9#
-//                       ^^^^^^^^ reference [..] macros.h:1:9#
+//        ^^^^^^^^^^^^^^ definition [..] `macros.h:9:9`!
+//                       ^^^^^^^^ reference [..] `macros.h:1:9`!

--- a/test/index/macros/system_header.snapshot.h
+++ b/test/index/macros/system_header.snapshot.h
@@ -1,8 +1,8 @@
   #pragma GCC system_header
   
   #define SYSTEM_INT 0
-//        ^^^^^^^^^^ definition [..] system_header.h:3:9#
+//        ^^^^^^^^^^ definition [..] `system_header.h:3:9`!
   
   #define OTHER_SYSTEM_INT (SYSTEM_INT + 1)
-//        ^^^^^^^^^^^^^^^^ definition [..] system_header.h:5:9#
-//                          ^^^^^^^^^^ reference [..] system_header.h:3:9#
+//        ^^^^^^^^^^^^^^^^ definition [..] `system_header.h:5:9`!
+//                          ^^^^^^^^^^ reference [..] `system_header.h:3:9`!

--- a/test/index/macros/use_system_header.snapshot.cc
+++ b/test/index/macros/use_system_header.snapshot.cc
@@ -1,5 +1,5 @@
   #include "system_header.h"
   
   const int total = SYSTEM_INT + OTHER_SYSTEM_INT;
-//                  ^^^^^^^^^^ reference [..] system_header.h:3:9#
-//                               ^^^^^^^^^^^^^^^^ reference [..] system_header.h:5:9#
+//                  ^^^^^^^^^^ reference [..] `system_header.h:3:9`!
+//                               ^^^^^^^^^^^^^^^^ reference [..] `system_header.h:5:9`!

--- a/test/index/namespaces/namespaces.snapshot.cc
+++ b/test/index/namespaces/namespaces.snapshot.cc
@@ -13,7 +13,7 @@
   }
   
   namespace {
-//^^^^^^^^^ definition [..] $ANON/namespaces.cc/
+//^^^^^^^^^ definition [..] `$anonymous_namespace_namespaces.cc`/
   }
   
   inline namespace xx {
@@ -24,7 +24,7 @@
 //          ^ definition [..] z/
   
   inline namespace {
-//       ^^^^^^^^^ definition [..] $ANON/namespaces.cc/
+//       ^^^^^^^^^ definition [..] z/`$anonymous_namespace_namespaces.cc`/
   }
   
   }
@@ -44,27 +44,27 @@
   using C = c::C;
   
   #define EXPAND_TO_NAMESPACE \
-//        ^^^^^^^^^^^^^^^^^^^ definition [..] namespaces.cc:36:9#
+//        ^^^^^^^^^^^^^^^^^^^ definition [..] `namespaces.cc:36:9`!
     namespace from_macro {}
   
   EXPAND_TO_NAMESPACE
 //^^^^^^^^^^^^^^^^^^^ definition [..] from_macro/
-//^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:36:9#
+//^^^^^^^^^^^^^^^^^^^ reference [..] `namespaces.cc:36:9`!
   
   #define EXPAND_TO_NAMESPACE_2 EXPAND_TO_NAMESPACE
-//        ^^^^^^^^^^^^^^^^^^^^^ definition [..] namespaces.cc:41:9#
-//                              ^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:36:9#
+//        ^^^^^^^^^^^^^^^^^^^^^ definition [..] `namespaces.cc:41:9`!
+//                              ^^^^^^^^^^^^^^^^^^^ reference [..] `namespaces.cc:36:9`!
   
   EXPAND_TO_NAMESPACE_2
 //^^^^^^^^^^^^^^^^^^^^^ definition [..] from_macro/
-//^^^^^^^^^^^^^^^^^^^^^ reference [..] namespaces.cc:41:9#
+//^^^^^^^^^^^^^^^^^^^^^ reference [..] `namespaces.cc:41:9`!
   
   #define IDENTITY(x) x
-//        ^^^^^^^^ definition [..] namespaces.cc:45:9#
+//        ^^^^^^^^ definition [..] `namespaces.cc:45:9`!
   
   IDENTITY(namespace in_macro { })
 //^^^^^^^^ definition [..] in_macro/
-//^^^^^^^^ reference [..] namespaces.cc:45:9#
+//^^^^^^^^ reference [..] `namespaces.cc:45:9`!
   
   namespace a {
 //          ^ definition [..] a/

--- a/test/index/types/types.snapshot.cc
+++ b/test/index/types/types.snapshot.cc
@@ -3,7 +3,7 @@
   #include "types.h"
   
   enum {
-//^^^^ definition [..] $anontype_9a8b4e83cf46cb05_0#
+//^^^^ definition [..] $anonymous_type_9a8b4e83cf46cb05_0#
     ANON,
 //  ^^^^ definition [..] ANON.
   };
@@ -45,7 +45,7 @@
     class X {};
   
     namespace {
-//  ^^^^^^^^^ definition [..] $ANON/types.cc/
+//  ^^^^^^^^^ definition [..] a/`$anonymous_namespace_types.cc`/
       class Y {};
     }
   }
@@ -53,7 +53,7 @@
   namespace has_anon_enum {
 //          ^^^^^^^^^^^^^ definition [..] has_anon_enum/
     enum {
-//  ^^^^ definition [..] has_anon_enum/$anontype_9a8b4e83cf46cb05_1#
+//  ^^^^ definition [..] has_anon_enum/$anonymous_type_9a8b4e83cf46cb05_1#
       /* Here a moo, there a moo */
       F1,
 //    ^^ definition [..] has_anon_enum/F1.
@@ -73,10 +73,10 @@
     friend F0;
   
     enum { ANON1 } anon1;
-//  ^^^^ definition [..] F1#$anontype_2#
+//  ^^^^ definition [..] F1#$anonymous_type_2#
 //         ^^^^^ definition [..] F1#ANON1.
     enum { ANON2 = ANON1 } anon2;
-//  ^^^^ definition [..] F1#$anontype_3#
+//  ^^^^ definition [..] F1#$anonymous_type_3#
 //         ^^^^^ definition [..] F1#ANON2.
 //                 ^^^^^ reference [..] F1#ANON1.
   };
@@ -96,14 +96,14 @@
   }
   
   #define VISIT(_name) Visit##_name
-//        ^^^^^ definition [..] types.cc:69:9#
+//        ^^^^^ definition [..] `types.cc:69:9`!
   
   enum VISIT(Sightseeing) {
-//     ^^^^^ reference [..] types.cc:69:9#
+//     ^^^^^ reference [..] `types.cc:69:9`!
 //     ^^^^^ definition [..] VisitSightseeing#
     VISIT(Museum),
 //  ^^^^^ definition [..] VisitMuseum.
-//  ^^^^^ reference [..] types.cc:69:9#
+//  ^^^^^ reference [..] `types.cc:69:9`!
   };
   
   // Regression test for https://github.com/sourcegraph/scip-clang/issues/105
@@ -135,11 +135,11 @@
 //          ^ reference [..] E#
 //             ^^ reference [..] E#E0.
   #define QUALIFIED(enum_name, case_name) enum_name::case_name;
-//        ^^^^^^^^^ definition [..] types.cc:90:9#
+//        ^^^^^^^^^ definition [..] `types.cc:90:9`!
     (void)QUALIFIED(E, E0);
 //        ^^^^^^^^^ reference [..] E#
 //        ^^^^^^^^^ reference [..] E#E0.
-//        ^^^^^^^^^ reference [..] types.cc:90:9#
+//        ^^^^^^^^^ reference [..] `types.cc:90:9`!
   #undef QUALIFIED
-//       ^^^^^^^^^ reference [..] types.cc:90:9#
+//       ^^^^^^^^^ reference [..] `types.cc:90:9`!
   }

--- a/test/index/types/types.snapshot.h
+++ b/test/index/types/types.snapshot.h
@@ -2,7 +2,7 @@
   namespace has_anon_enum {
 //          ^^^^^^^^^^^^^ definition [..] has_anon_enum/
     enum { E1, E2 } e = E1;
-//  ^^^^ definition [..] has_anon_enum/$anontype_a58c49fe3a7ec9aa_0#
+//  ^^^^ definition [..] has_anon_enum/$anonymous_type_a58c49fe3a7ec9aa_0#
 //         ^^ definition [..] has_anon_enum/E1.
 //             ^^ definition [..] has_anon_enum/E2.
 //                      ^^ reference [..] has_anon_enum/E1.


### PR DESCRIPTION
Consolidates symbol formatting logic to handle escaping etc.
This also avoids most direct accesses to the `scratchBuffer`,
which is mostly used behind a couple of methods.

This addresses one of the points of feedback from earlier,
with the symbol formatting logic being scattered across
different places. Now is a good time to introduce this, before
adding support for local variables.