### PR TITLE
feat: Emit defs & refs for functions & methods

### DIFF
--- a/docs/Design.md
+++ b/docs/Design.md
@@ -566,6 +566,7 @@ There are 4 possible cases here:
    to the corresponding synthetic standard library package
    (e.g. `libc++@15.0.0`).
 
+<!-- TODO(def: handle-forward-decls) -->
 For simplicity, an initial implementation
 can put fake `SymbolInformation` values
 in the `external_symbols` list

--- a/indexer/Indexer.h
+++ b/indexer/Indexer.h
@@ -21,6 +21,10 @@
 #include "indexer/ScipExtras.h"
 #include "indexer/SymbolFormatter.h"
 
+#define FOR_EACH_EXPR_TO_BE_INDEXED(F) \
+  F(DeclRef)                           \
+  F(Member)
+
 #define FOR_EACH_TYPE_TO_BE_INDEXED(F) \
   F(Enum)                              \
   F(Record)
@@ -30,13 +34,16 @@ namespace clang {
 FOR_EACH_DECL_TO_BE_INDEXED(FORWARD_DECLARE)
 #undef FORWARD_DECLARE
 
+#define FORWARD_DECLARE(ExprName) class ExprName##Expr;
+FOR_EACH_EXPR_TO_BE_INDEXED(FORWARD_DECLARE)
+#undef FORWARD_DECLARE
+
 #define FORWARD_DECLARE(TypeName) class TypeName##TypeLoc;
 FOR_EACH_TYPE_TO_BE_INDEXED(FORWARD_DECLARE)
 #undef FORWARD_DECLARE
 
 class ASTContext;
 class Decl;
-class DeclRefExpr;
 class MacroDefinition;
 class MacroInfo;
 class NestedNameSpecifierLoc;
@@ -213,7 +220,10 @@ public:
   void saveTagDecl(const clang::TagDecl &);
   void saveTagTypeLoc(const clang::TagTypeLoc &);
 
-  void saveDeclRefExpr(const clang::DeclRefExpr &);
+#define SAVE_EXPR(ExprName) \
+  void save##ExprName##Expr(const clang::ExprName##Expr &);
+  FOR_EACH_EXPR_TO_BE_INDEXED(SAVE_EXPR)
+#undef SAVE_EXPR
   void saveNestedNameSpecifierLoc(const clang::NestedNameSpecifierLoc &);
 
 #define SAVE_TYPE_LOC(TypeName) \

--- a/indexer/SymbolFormatter.h
+++ b/indexer/SymbolFormatter.h
@@ -20,6 +20,7 @@
   F(Binding)                           \
   F(EnumConstant)                      \
   F(Enum)                              \
+  F(Function)                          \
   F(Namespace)                         \
   F(Record)                            \
   F(Var)

--- a/indexer/Worker.cc
+++ b/indexer/Worker.cc
@@ -705,10 +705,14 @@ public:
   FOR_EACH_DECL_TO_BE_INDEXED(VISIT_DECL)
 #undef VISIT_DECL
 
-  bool VisitDeclRefExpr(clang::DeclRefExpr *declRefExpr) {
-    this->tuIndexer.saveDeclRefExpr(*declRefExpr);
-    return true;
+#define VISIT_EXPR(ExprName)                                     \
+  bool Visit##ExprName##Expr(clang::ExprName##Expr *expr) {      \
+    ENFORCE(expr, "expected " #ExprName "Expr to be null-null"); \
+    this->tuIndexer.save##ExprName##Expr(*expr);                 \
+    return true;                                                 \
   }
+  FOR_EACH_EXPR_TO_BE_INDEXED(VISIT_EXPR)
+#undef VISIT_EXPR
 
 #define VISIT_TYPE_LOC(TypeName)                                    \
   bool Visit##TypeName##TypeLoc(clang::TypeName##TypeLoc typeLoc) { \

--- a/test/Snapshot.cc
+++ b/test/Snapshot.cc
@@ -167,7 +167,8 @@ void formatSnapshot(const scip::Document &document,
       }
 
       ENFORCE(range.start.column < range.end.column,
-              "We shouldn't be emitting empty ranges 🙅");
+              "Found empty range for {} at {}:{}:{}", occ.symbol(),
+               sourceFilePath.asStringView(), range.start.line, range.start.column);
 
       auto lineStart =
           absl::StrCat("//", std::string(range.start.column - 1, ' '));

--- a/test/Snapshot.cc
+++ b/test/Snapshot.cc
@@ -168,7 +168,8 @@ void formatSnapshot(const scip::Document &document,
 
       ENFORCE(range.start.column < range.end.column,
               "Found empty range for {} at {}:{}:{}", occ.symbol(),
-               sourceFilePath.asStringView(), range.start.line, range.start.column);
+              sourceFilePath.asStringView(), range.start.line,
+              range.start.column);
 
       auto lineStart =
           absl::StrCat("//", std::string(range.start.column - 1, ' '));
@@ -294,13 +295,17 @@ void MultiTuSnapshotTest::run(SnapshotMode mode,
   absl::flat_hash_map<RootRelativePath, RootRelativePath> alreadyUsedFiles;
 
   for (auto &io : this->inputOutputs) {
-    auto &sourceFilePath = io.sourceFilePath.asStringRef();
-    if (!test::isTuMainFilePath(sourceFilePath)) {
+    auto &sourceFileRelPath = io.sourceFilePath.asStringRef();
+    if (!test::isTuMainFilePath(sourceFileRelPath)) {
       continue;
     }
-    std::vector<std::string> commandLine{"clang", "-I", ".", sourceFilePath};
+    std::vector<std::string> commandLine{"clang", "-I", ".", sourceFileRelPath};
     {
-      std::ifstream tuStream(sourceFilePath, std::ios::in | std::ios::binary);
+      auto sourceFileAbsPath =
+          this->rootPath.makeAbsolute(io.sourceFilePath.asRef());
+      ENFORCE(std::filesystem::exists(sourceFileAbsPath.asStringRef()));
+      std::ifstream tuStream(sourceFileAbsPath.asStringRef(),
+                             std::ios::in | std::ios::binary);
       std::string prefix = "// extra-args: ";
       for (std::string line; std::getline(tuStream, line);) {
         if (!line.starts_with(prefix)) {
@@ -315,8 +320,8 @@ void MultiTuSnapshotTest::run(SnapshotMode mode,
       }
     }
 
-    auto output =
-        compute(rootPath, io.sourceFilePath.asRef(), std::move(commandLine));
+    auto output = compute(this->rootPath, io.sourceFilePath.asRef(),
+                          std::move(commandLine));
 
     for (auto &[filePath, _] : output) {
       ENFORCE(!alreadyUsedFiles.contains(filePath),

--- a/test/index/functions/ctors_dtors.cc
+++ b/test/index/functions/ctors_dtors.cc
@@ -1,0 +1,54 @@
+// extra-args: -std=c++20
+
+template<class T> struct remove_ref      { typedef T type; };
+template<class T> struct remove_ref<T&>  { typedef T type; };
+template<class T> struct remove_ref<T&&> { typedef T type; };
+
+template <typename T>
+typename remove_ref<T>::type&& move(T&& arg) {
+  return static_cast<typename remove_ref<T>::type&&>(arg);
+}
+
+struct C {
+  int x;
+  int y;
+};
+
+struct D {
+  int x;
+  int y;
+
+  D() = default;
+  D(const D &) = default;
+  D(D &&) = default;
+  D &operator=(const D &) = default;
+  D &operator=(D &&) = default;
+};
+
+void test_ctors() {
+  C c0;
+  D d0;
+  C c1{};
+  D d1{};
+  C c2{0, 1};
+  // TODO: Figure out a minimal stub for std::initializer_list,
+  // which we can use here, without running into Clang's
+  // "cannot compile this weird std::initializer_list yet" error
+  // D d2{0, 1};
+  C c3{move(c1)};
+  D d3{move(d1)};
+
+  C c4 = {};
+  D d4 = {};
+  C c5 = C();
+  D d5 = D();
+  C c6 = {0, 1};
+  // Uncomment after adding initializer_list
+  // D d6 = {0, 1};
+
+  C c7 = {.x = 0};
+  C c8 = {.x = 0, .y = 1};
+  C c9 = C{0, 1};
+  C c10 = move(c1);
+  D d10 = move(d1);
+}

--- a/test/index/functions/ctors_dtors.snapshot.cc
+++ b/test/index/functions/ctors_dtors.snapshot.cc
@@ -1,0 +1,115 @@
+  // extra-args: -std=c++20
+  
+  template<class T> struct remove_ref      { typedef T type; };
+//                         ^^^^^^^^^^ definition [..] remove_ref#
+  template<class T> struct remove_ref<T&>  { typedef T type; };
+//                         ^^^^^^^^^^ definition [..] remove_ref#
+  template<class T> struct remove_ref<T&&> { typedef T type; };
+//                         ^^^^^^^^^^ definition [..] remove_ref#
+  
+  template <typename T>
+  typename remove_ref<T>::type&& move(T&& arg) {
+//                               ^^^^ definition [..] move(721d19cf58c53974).
+//                                        ^^^ definition local 0
+    return static_cast<typename remove_ref<T>::type&&>(arg);
+//                                                     ^^^ reference local 0
+  }
+  
+  struct C {
+//       ^ definition [..] C#
+    int x;
+    int y;
+  };
+  
+  struct D {
+//       ^ definition [..] D#
+    int x;
+    int y;
+  
+    D() = default;
+//  ^ definition [..] D#D(ced63f7c635d850d).
+    D(const D &) = default;
+//  ^ definition [..] D#D(cf67c1cd7b9892d0).
+//          ^ reference [..] D#
+    D(D &&) = default;
+//  ^ definition [..] D#D(ece7426db7e2c886).
+//    ^ reference [..] D#
+    D &operator=(const D &) = default;
+//  ^ reference [..] D#
+//     ^^^^^^^^ definition [..] D#`operator=`(37b1797afc85ed93).
+//                     ^ reference [..] D#
+    D &operator=(D &&) = default;
+//  ^ reference [..] D#
+//     ^^^^^^^^ definition [..] D#`operator=`(1c0a0df55fbfcacb).
+//               ^ reference [..] D#
+  };
+  
+  void test_ctors() {
+//     ^^^^^^^^^^ definition [..] test_ctors(49f6e7a06ebc5aa8).
+    C c0;
+//  ^ reference [..] C#
+//    ^^ definition local 1
+    D d0;
+//  ^ reference [..] D#
+//    ^^ definition local 2
+    C c1{};
+//  ^ reference [..] C#
+//    ^^ definition local 3
+    D d1{};
+//  ^ reference [..] D#
+//    ^^ definition local 4
+    C c2{0, 1};
+//  ^ reference [..] C#
+//    ^^ definition local 5
+    // TODO: Figure out a minimal stub for std::initializer_list,
+    // which we can use here, without running into Clang's
+    // "cannot compile this weird std::initializer_list yet" error
+    // D d2{0, 1};
+    C c3{move(c1)};
+//  ^ reference [..] C#
+//    ^^ definition local 6
+//            ^^ reference local 3
+    D d3{move(d1)};
+//  ^ reference [..] D#
+//    ^^ definition local 7
+//            ^^ reference local 4
+  
+    C c4 = {};
+//  ^ reference [..] C#
+//    ^^ definition local 8
+    D d4 = {};
+//  ^ reference [..] D#
+//    ^^ definition local 9
+    C c5 = C();
+//  ^ reference [..] C#
+//    ^^ definition local 10
+//         ^ reference [..] C#
+    D d5 = D();
+//  ^ reference [..] D#
+//    ^^ definition local 11
+//         ^ reference [..] D#
+    C c6 = {0, 1};
+//  ^ reference [..] C#
+//    ^^ definition local 12
+    // Uncomment after adding initializer_list
+    // D d6 = {0, 1};
+  
+    C c7 = {.x = 0};
+//  ^ reference [..] C#
+//    ^^ definition local 13
+    C c8 = {.x = 0, .y = 1};
+//  ^ reference [..] C#
+//    ^^ definition local 14
+    C c9 = C{0, 1};
+//  ^ reference [..] C#
+//    ^^ definition local 15
+//         ^ reference [..] C#
+    C c10 = move(c1);
+//  ^ reference [..] C#
+//    ^^^ definition local 16
+//               ^^ reference local 3
+    D d10 = move(d1);
+//  ^ reference [..] D#
+//    ^^^ definition local 17
+//               ^^ reference local 4
+  }

--- a/test/index/functions/functions.cc
+++ b/test/index/functions/functions.cc
@@ -1,0 +1,27 @@
+void top_level_func() {}
+
+namespace my_namespace {
+  void func_in_namespace() {}
+}
+
+void overloaded_func(int) {}
+void overloaded_func(const char *) {
+  overloaded_func(32);
+}
+
+void shadowed_func() {}
+
+namespace detail {
+  void shadowed_func() {
+    shadowed_func();
+  }
+}
+
+void use_outer() {
+  shadowed_func();
+}
+
+// check that the same canonical type produces the same hash
+using IntAlias = int;
+void int_to_void_fn(int) {}
+void same_hash_as_previous(IntAlias) {}

--- a/test/index/functions/functions.snapshot.cc
+++ b/test/index/functions/functions.snapshot.cc
@@ -1,0 +1,41 @@
+  void top_level_func() {}
+//     ^^^^^^^^^^^^^^ definition [..] top_level_func(49f6e7a06ebc5aa8).
+  
+  namespace my_namespace {
+//          ^^^^^^^^^^^^ definition [..] my_namespace/
+    void func_in_namespace() {}
+//       ^^^^^^^^^^^^^^^^^ definition [..] my_namespace/func_in_namespace(49f6e7a06ebc5aa8).
+  }
+  
+  void overloaded_func(int) {}
+//     ^^^^^^^^^^^^^^^ definition [..] overloaded_func(d4f767463ce0a6b3).
+  void overloaded_func(const char *) {
+//     ^^^^^^^^^^^^^^^ definition [..] overloaded_func(85c52e162fed56f9).
+    overloaded_func(32);
+//  ^^^^^^^^^^^^^^^ reference [..] overloaded_func(d4f767463ce0a6b3).
+  }
+  
+  void shadowed_func() {}
+//     ^^^^^^^^^^^^^ definition [..] shadowed_func(49f6e7a06ebc5aa8).
+  
+  namespace detail {
+//          ^^^^^^ definition [..] detail/
+    void shadowed_func() {
+//       ^^^^^^^^^^^^^ definition [..] detail/shadowed_func(49f6e7a06ebc5aa8).
+      shadowed_func();
+//    ^^^^^^^^^^^^^ reference [..] detail/shadowed_func(49f6e7a06ebc5aa8).
+    }
+  }
+  
+  void use_outer() {
+//     ^^^^^^^^^ definition [..] use_outer(49f6e7a06ebc5aa8).
+    shadowed_func();
+//  ^^^^^^^^^^^^^ reference [..] shadowed_func(49f6e7a06ebc5aa8).
+  }
+  
+  // check that the same canonical type produces the same hash
+  using IntAlias = int;
+  void int_to_void_fn(int) {}
+//     ^^^^^^^^^^^^^^ definition [..] int_to_void_fn(d4f767463ce0a6b3).
+  void same_hash_as_previous(IntAlias) {}
+//     ^^^^^^^^^^^^^^^^^^^^^ definition [..] same_hash_as_previous(d4f767463ce0a6b3).

--- a/test/index/functions/methods.cc
+++ b/test/index/functions/methods.cc
@@ -1,0 +1,77 @@
+// Virtual methods and inheritance
+
+struct S0 {
+  virtual void v1() {
+    v2();
+  }
+  virtual void v2() {}
+  virtual void v3() {}
+  virtual void v4() {}
+  virtual void v5() = 0;
+
+};
+
+struct S1_0: S0 {
+  virtual void v1() override { v2(); }
+  virtual void v2() /*override*/ {}
+};
+
+struct S1_1: S0 {
+  virtual void v2() override { v1(); }
+  virtual void v3() override { v5(); }
+};
+
+struct S2 final: S1_0, S1_1 {
+  virtual void v1() override { v5(); }
+  virtual void v2() override {}
+  virtual void v3() override {}
+  virtual void v4() override {}
+  virtual void v5() override {}
+};
+
+// Method forward declarations
+
+struct A0 {
+  void f();
+  static void g();
+  struct B0 {
+    void f();
+    static void g();
+  };
+  friend bool operator==(const A0 &, const A0 &);
+};
+
+void A0::f() {}
+void A0::g() {}
+void A0::B0::f() {}
+void A0::B0::g() {}
+
+// Not A::operator==
+bool operator==(const A0 &, const A0 &) { return true; }
+
+// Static methods
+
+struct Z0 {
+  static void f();
+  void g() { f(); }
+};
+
+struct Z1: Z0 {
+  void h() {
+    f();
+    Z1::f();
+    Z0::f();
+  }
+};
+
+// Member function pointer
+
+struct M0 {
+  void f() {}
+};
+
+void test_member_pointer() {
+  void (M0::*p)() = &M0::f;
+  M0 m{};
+  (m.*p)();
+}

--- a/test/index/functions/methods.snapshot.cc
+++ b/test/index/functions/methods.snapshot.cc
@@ -1,0 +1,166 @@
+  // Virtual methods and inheritance
+  
+  struct S0 {
+//       ^^ definition [..] S0#
+    virtual void v1() {
+//               ^^ definition [..] S0#v1(49f6e7a06ebc5aa8).
+      v2();
+//    ^^ reference [..] S0#v2(49f6e7a06ebc5aa8).
+    }
+    virtual void v2() {}
+//               ^^ definition [..] S0#v2(49f6e7a06ebc5aa8).
+    virtual void v3() {}
+//               ^^ definition [..] S0#v3(49f6e7a06ebc5aa8).
+    virtual void v4() {}
+//               ^^ definition [..] S0#v4(49f6e7a06ebc5aa8).
+    virtual void v5() = 0;
+//               ^^ definition [..] S0#v5(49f6e7a06ebc5aa8).
+  
+  };
+  
+  struct S1_0: S0 {
+//       ^^^^ definition [..] S1_0#
+//       relation implementation [..] S0#
+//             ^^ reference [..] S0#
+    virtual void v1() override { v2(); }
+//               ^^ definition [..] S1_0#v1(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S0#v1(49f6e7a06ebc5aa8).
+//                               ^^ reference [..] S1_0#v2(49f6e7a06ebc5aa8).
+    virtual void v2() /*override*/ {}
+//               ^^ definition [..] S1_0#v2(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S0#v2(49f6e7a06ebc5aa8).
+  };
+  
+  struct S1_1: S0 {
+//       ^^^^ definition [..] S1_1#
+//       relation implementation [..] S0#
+//             ^^ reference [..] S0#
+    virtual void v2() override { v1(); }
+//               ^^ definition [..] S1_1#v2(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S0#v2(49f6e7a06ebc5aa8).
+//                               ^^ reference [..] S0#v1(49f6e7a06ebc5aa8).
+    virtual void v3() override { v5(); }
+//               ^^ definition [..] S1_1#v3(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S0#v3(49f6e7a06ebc5aa8).
+//                               ^^ reference [..] S0#v5(49f6e7a06ebc5aa8).
+  };
+  
+  struct S2 final: S1_0, S1_1 {
+//       ^^ definition [..] S2#
+//       relation implementation [..] S1_0#
+//       relation implementation [..] S1_1#
+//                 ^^^^ reference [..] S1_0#
+//                       ^^^^ reference [..] S1_1#
+    virtual void v1() override { v5(); }
+//               ^^ definition [..] S2#v1(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S0#v1(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S1_0#v1(49f6e7a06ebc5aa8).
+//                               ^^ reference [..] S2#v5(49f6e7a06ebc5aa8).
+    virtual void v2() override {}
+//               ^^ definition [..] S2#v2(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S1_0#v2(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S1_1#v2(49f6e7a06ebc5aa8).
+    virtual void v3() override {}
+//               ^^ definition [..] S2#v3(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S0#v3(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S1_1#v3(49f6e7a06ebc5aa8).
+    virtual void v4() override {}
+//               ^^ definition [..] S2#v4(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S0#v4(49f6e7a06ebc5aa8).
+    virtual void v5() override {}
+//               ^^ definition [..] S2#v5(49f6e7a06ebc5aa8).
+//               relation implementation+reference [..] S0#v5(49f6e7a06ebc5aa8).
+  };
+  
+  // Method forward declarations
+  
+  struct A0 {
+//       ^^ definition [..] A0#
+    void f();
+//       ^ reference [..] A0#f(49f6e7a06ebc5aa8).
+    static void g();
+//              ^ reference [..] A0#g(49f6e7a06ebc5aa8).
+    struct B0 {
+//         ^^ definition [..] A0#B0#
+      void f();
+//         ^ reference [..] A0#B0#f(49f6e7a06ebc5aa8).
+      static void g();
+//                ^ reference [..] A0#B0#g(49f6e7a06ebc5aa8).
+    };
+    friend bool operator==(const A0 &, const A0 &);
+//              ^^^^^^^^ reference [..] `operator==`(354ee8b82d643f9c).
+//                               ^^ reference [..] A0#
+//                                           ^^ reference [..] A0#
+  };
+  
+  void A0::f() {}
+//     ^^ reference [..] A0#
+//         ^ definition [..] A0#f(49f6e7a06ebc5aa8).
+  void A0::g() {}
+//     ^^ reference [..] A0#
+//         ^ definition [..] A0#g(49f6e7a06ebc5aa8).
+  void A0::B0::f() {}
+//     ^^ reference [..] A0#
+//         ^^ reference [..] A0#B0#
+//             ^ definition [..] A0#B0#f(49f6e7a06ebc5aa8).
+  void A0::B0::g() {}
+//     ^^ reference [..] A0#
+//         ^^ reference [..] A0#B0#
+//             ^ definition [..] A0#B0#g(49f6e7a06ebc5aa8).
+  
+  // Not A::operator==
+  bool operator==(const A0 &, const A0 &) { return true; }
+//     ^^^^^^^^ definition [..] `operator==`(354ee8b82d643f9c).
+//                      ^^ reference [..] A0#
+//                                  ^^ reference [..] A0#
+  
+  // Static methods
+  
+  struct Z0 {
+//       ^^ definition [..] Z0#
+    static void f();
+//              ^ reference [..] Z0#f(49f6e7a06ebc5aa8).
+    void g() { f(); }
+//       ^ definition [..] Z0#g(49f6e7a06ebc5aa8).
+//             ^ reference [..] Z0#f(49f6e7a06ebc5aa8).
+  };
+  
+  struct Z1: Z0 {
+//       ^^ definition [..] Z1#
+//       relation implementation [..] Z0#
+//           ^^ reference [..] Z0#
+    void h() {
+//       ^ definition [..] Z1#h(49f6e7a06ebc5aa8).
+      f();
+//    ^ reference [..] Z0#f(49f6e7a06ebc5aa8).
+      Z1::f();
+//    ^^ reference [..] Z1#
+//        ^ reference [..] Z0#f(49f6e7a06ebc5aa8).
+      Z0::f();
+//    ^^ reference [..] Z0#
+//        ^ reference [..] Z0#f(49f6e7a06ebc5aa8).
+    }
+  };
+  
+  // Member function pointer
+  
+  struct M0 {
+//       ^^ definition [..] M0#
+    void f() {}
+//       ^ definition [..] M0#f(49f6e7a06ebc5aa8).
+  };
+  
+  void test_member_pointer() {
+//     ^^^^^^^^^^^^^^^^^^^ definition [..] test_member_pointer(49f6e7a06ebc5aa8).
+    void (M0::*p)() = &M0::f;
+//        ^^ reference [..] M0#
+//             ^ definition local 0
+//                     ^^ reference [..] M0#
+//                         ^ reference [..] M0#f(49f6e7a06ebc5aa8).
+    M0 m{};
+//  ^^ reference [..] M0#
+//     ^ definition local 1
+    (m.*p)();
+//   ^ reference local 1
+//      ^ reference local 0
+  }

--- a/test/index/functions/operators.cc
+++ b/test/index/functions/operators.cc
@@ -1,0 +1,141 @@
+// extra-args: -std=c++2b
+
+// Overloaded operators
+
+struct MyStream {};
+
+MyStream &operator<<(MyStream &s, int) { return s; }
+MyStream &operator<<(MyStream &s, const char *) { return s; }
+
+struct Int { int val; };
+struct IntPair { Int x; Int y; };
+
+IntPair operator,(Int x, Int y) {
+  return IntPair{x, y};
+}
+
+Int operator++(Int &i, int) {
+  return Int{i.val+1};
+}
+
+struct FnLike {
+  int operator()() { return 0; }
+};
+
+struct Table {
+  int value;
+  int &operator[](int i, int j) { // since C++23
+    return this->value;
+  }
+};
+
+struct TablePtr {
+  Table *t;
+  Table *operator->() { return t; }
+};
+
+void test_overloaded_operators() {
+  MyStream s{};
+  s << 0 << "nothing to see here";
+  Int x{0};
+  Int y{0};
+  IntPair p = (x, y);
+  p.x++;
+
+  FnLike()();
+  Table{}[0, 1];
+  TablePtr{}->value;
+}
+
+// User-defined conversion function
+
+// Based on https://en.cppreference.com/w/cpp/language/cast_operator
+struct IntConvertible {
+  operator int() const { return 0; }
+  explicit operator const char*() const { return "aaa"; }
+  using arr_t = int[3];
+  operator arr_t*() const { return nullptr; }
+};
+
+void test_implicit_conversion() {
+  IntConvertible x;
+  (void)static_cast<int>(x);
+  int m = x;
+  (void)static_cast<const char *>(x);
+  int (*pa)[3] = x;
+}
+
+// Allocation and deallocation
+
+#if _WIN32
+using size_t = unsigned long long;
+#else
+using size_t = unsigned long;
+#endif
+
+// Override global stuff
+void *operator new(size_t) { return nullptr; }
+void *operator new[](size_t) { return nullptr; }
+void operator delete(void *) noexcept {}
+void operator delete[](void *) noexcept {}
+
+struct Arena {};
+
+struct InArena {
+  static void *operator new(size_t count, Arena &) {
+    return ::operator new(count);
+  }
+  static void *operator new[](size_t count, Arena &) {
+    return ::operator new[](count);
+  }
+  static void operator delete(void *p) {
+    return ::operator delete(p);
+  }
+  static void operator delete[](void *p) {
+    return ::operator delete[](p);
+  }
+  // These two delete operations are only implicitly called
+  // if the corresponding operator new has an exception.
+  static void operator delete(void *p, Arena &) {
+    return ::operator delete(p);
+  }
+  static void operator delete[](void *p, Arena &) {
+    return ::operator delete[](p);
+  }
+};
+
+void test_new_delete() {
+  int *x = new int;
+  delete x;
+  int *xs = new int[4];
+  delete[] xs;
+
+  Arena a{};
+  auto *p1 = new (a) InArena;
+  delete p1;
+  auto *p2 = new (a) InArena[3];
+  delete[] p2;
+}
+
+// User-defined literals
+
+void operator ""_ull_lit(unsigned long long) { return; }
+void operator ""_raw_lit(const char *) { return; }
+
+template <char...>
+void operator""_templated_lit() {}
+
+struct A { constexpr A(const char *) {} };
+
+template <A a> // since C++20
+void operator ""_a_op() { return; }
+
+void test_literals() {
+  123_ull_lit;
+  123_raw_lit;
+  123_templated_lit;
+  "123"_a_op; // invokes operator""_a_op<A("123")>
+}
+
+// Overloaded co_await
+// FIXME(issue: https://github.com/sourcegraph/scip-clang/issues/125)

--- a/test/index/functions/operators.snapshot.cc
+++ b/test/index/functions/operators.snapshot.cc
@@ -103,6 +103,8 @@
 //  ^^^^^^ reference [..] FnLike#
 //          ^ reference [..] FnLike#`operator()`(b126dc7c1de90089).
     Table{}[0, 1];
+//  ^^^^^ reference [..] Table#
+//         ^ reference [..] Table#`operator[]`(77cf9b7ed2f5124c).
     TablePtr{}->value;
 //  ^^^^^^^^ reference [..] TablePtr#
 //            ^^ reference [..] TablePtr#`operator->`(ed921902444779f1).
@@ -269,6 +271,7 @@
     123_templated_lit;
 //     ^^^^^^^^^^^^^^ reference [..] `operator""_templated_lit`(49f6e7a06ebc5aa8).
     "123"_a_op; // invokes operator""_a_op<A("123")>
+//       ^^^^^ reference [..] `operator""_a_op`(49f6e7a06ebc5aa8).
   }
   
   // Overloaded co_await

--- a/test/index/functions/operators.snapshot.cc
+++ b/test/index/functions/operators.snapshot.cc
@@ -1,0 +1,275 @@
+  // extra-args: -std=c++2b
+  
+  // Overloaded operators
+  
+  struct MyStream {};
+//       ^^^^^^^^ definition [..] MyStream#
+  
+  MyStream &operator<<(MyStream &s, int) { return s; }
+//^^^^^^^^ reference [..] MyStream#
+//          ^^^^^^^^ definition [..] `operator<<`(97f6638197cf8bc4).
+//                     ^^^^^^^^ reference [..] MyStream#
+//                               ^ definition local 0
+//                                                ^ reference local 0
+  MyStream &operator<<(MyStream &s, const char *) { return s; }
+//^^^^^^^^ reference [..] MyStream#
+//          ^^^^^^^^ definition [..] `operator<<`(5651711ec4adbebf).
+//                     ^^^^^^^^ reference [..] MyStream#
+//                               ^ definition local 1
+//                                                         ^ reference local 1
+  
+  struct Int { int val; };
+//       ^^^ definition [..] Int#
+  struct IntPair { Int x; Int y; };
+//       ^^^^^^^ definition [..] IntPair#
+//                 ^^^ reference [..] Int#
+//                        ^^^ reference [..] Int#
+  
+  IntPair operator,(Int x, Int y) {
+//^^^^^^^ reference [..] IntPair#
+//        ^^^^^^^^ definition [..] `operator,`(56a2b3932346e301).
+//                  ^^^ reference [..] Int#
+//                      ^ definition local 2
+//                         ^^^ reference [..] Int#
+//                             ^ definition local 3
+    return IntPair{x, y};
+//         ^^^^^^^ reference [..] IntPair#
+//                 ^ reference local 2
+//                    ^ reference local 3
+  }
+  
+  Int operator++(Int &i, int) {
+//^^^ reference [..] Int#
+//    ^^^^^^^^ definition [..] operator++(be31e3af2b2ba0e).
+//               ^^^ reference [..] Int#
+//                    ^ definition local 4
+    return Int{i.val+1};
+//         ^^^ reference [..] Int#
+//             ^ reference local 4
+  }
+  
+  struct FnLike {
+//       ^^^^^^ definition [..] FnLike#
+    int operator()() { return 0; }
+//      ^^^^^^^^ definition [..] FnLike#`operator()`(b126dc7c1de90089).
+  };
+  
+  struct Table {
+//       ^^^^^ definition [..] Table#
+    int value;
+    int &operator[](int i, int j) { // since C++23
+//       ^^^^^^^^ definition [..] Table#`operator[]`(77cf9b7ed2f5124c).
+//                      ^ definition local 5
+//                             ^ definition local 6
+      return this->value;
+    }
+  };
+  
+  struct TablePtr {
+//       ^^^^^^^^ definition [..] TablePtr#
+    Table *t;
+//  ^^^^^ reference [..] Table#
+    Table *operator->() { return t; }
+//  ^^^^^ reference [..] Table#
+//         ^^^^^^^^ definition [..] TablePtr#`operator->`(ed921902444779f1).
+  };
+  
+  void test_overloaded_operators() {
+//     ^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] test_overloaded_operators(49f6e7a06ebc5aa8).
+    MyStream s{};
+//  ^^^^^^^^ reference [..] MyStream#
+//           ^ definition local 7
+    s << 0 << "nothing to see here";
+//  ^ reference local 7
+//    ^^ reference [..] `operator<<`(97f6638197cf8bc4).
+//         ^^ reference [..] `operator<<`(5651711ec4adbebf).
+    Int x{0};
+//  ^^^ reference [..] Int#
+//      ^ definition local 8
+    Int y{0};
+//  ^^^ reference [..] Int#
+//      ^ definition local 9
+    IntPair p = (x, y);
+//  ^^^^^^^ reference [..] IntPair#
+//          ^ definition local 10
+//               ^ reference local 8
+//                ^ reference [..] `operator,`(56a2b3932346e301).
+//                  ^ reference local 9
+    p.x++;
+//  ^ reference local 10
+//     ^^ reference [..] operator++(be31e3af2b2ba0e).
+  
+    FnLike()();
+//  ^^^^^^ reference [..] FnLike#
+//          ^ reference [..] FnLike#`operator()`(b126dc7c1de90089).
+    Table{}[0, 1];
+    TablePtr{}->value;
+//  ^^^^^^^^ reference [..] TablePtr#
+//            ^^ reference [..] TablePtr#`operator->`(ed921902444779f1).
+  }
+  
+  // User-defined conversion function
+  
+  // Based on https://en.cppreference.com/w/cpp/language/cast_operator
+  struct IntConvertible {
+//       ^^^^^^^^^^^^^^ definition [..] IntConvertible#
+    operator int() const { return 0; }
+//  ^^^^^^^^ definition [..] IntConvertible#`operator int`(455f465bc33b4cdf).
+    explicit operator const char*() const { return "aaa"; }
+//           ^^^^^^^^ definition [..] IntConvertible#`operator const char *`(a9f41ea0e82d88cf).
+    using arr_t = int[3];
+    operator arr_t*() const { return nullptr; }
+//  ^^^^^^^^ definition [..] IntConvertible#`operator int (*)[3]`(a00bb5473f10e296).
+  };
+  
+  void test_implicit_conversion() {
+//     ^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] test_implicit_conversion(49f6e7a06ebc5aa8).
+    IntConvertible x;
+//  ^^^^^^^^^^^^^^ reference [..] IntConvertible#
+//                 ^ definition local 11
+    (void)static_cast<int>(x);
+//                         ^ reference local 11
+    int m = x;
+//      ^ definition local 12
+//          ^ reference local 11
+    (void)static_cast<const char *>(x);
+//                                  ^ reference local 11
+    int (*pa)[3] = x;
+//        ^^ definition local 13
+//                 ^ reference local 11
+  }
+  
+  // Allocation and deallocation
+  
+  #if _WIN32
+  using size_t = unsigned long long;
+  #else
+  using size_t = unsigned long;
+  #endif
+  
+  // Override global stuff
+  void *operator new(size_t) { return nullptr; }
+//      ^^^^^^^^ definition [..] `operator new`(bfcfa4d6b7f7ef64).
+  void *operator new[](size_t) { return nullptr; }
+//      ^^^^^^^^ definition [..] `operator new[]`(bfcfa4d6b7f7ef64).
+  void operator delete(void *) noexcept {}
+//     ^^^^^^^^ definition [..] `operator delete`(bd21765a0afc8e3c).
+  void operator delete[](void *) noexcept {}
+//     ^^^^^^^^ definition [..] `operator delete[]`(bd21765a0afc8e3c).
+  
+  struct Arena {};
+//       ^^^^^ definition [..] Arena#
+  
+  struct InArena {
+//       ^^^^^^^ definition [..] InArena#
+    static void *operator new(size_t count, Arena &) {
+//               ^^^^^^^^ definition [..] InArena#`operator new`(747707f21471d499).
+//                                   ^^^^^ definition local 14
+//                                          ^^^^^ reference [..] Arena#
+      return ::operator new(count);
+//             ^^^^^^^^ reference [..] `operator new`(bfcfa4d6b7f7ef64).
+//                          ^^^^^ reference local 14
+    }
+    static void *operator new[](size_t count, Arena &) {
+//               ^^^^^^^^ definition [..] InArena#`operator new[]`(747707f21471d499).
+//                                     ^^^^^ definition local 15
+//                                            ^^^^^ reference [..] Arena#
+      return ::operator new[](count);
+//             ^^^^^^^^ reference [..] `operator new[]`(bfcfa4d6b7f7ef64).
+//                            ^^^^^ reference local 15
+    }
+    static void operator delete(void *p) {
+//              ^^^^^^^^ definition [..] InArena#`operator delete`(bd21765a0afc8e3c).
+//                                    ^ definition local 16
+      return ::operator delete(p);
+//             ^^^^^^^^ reference [..] `operator delete`(bd21765a0afc8e3c).
+//                             ^ reference local 16
+    }
+    static void operator delete[](void *p) {
+//              ^^^^^^^^ definition [..] InArena#`operator delete[]`(bd21765a0afc8e3c).
+//                                      ^ definition local 17
+      return ::operator delete[](p);
+//             ^^^^^^^^ reference [..] `operator delete[]`(bd21765a0afc8e3c).
+//                               ^ reference local 17
+    }
+    // These two delete operations are only implicitly called
+    // if the corresponding operator new has an exception.
+    static void operator delete(void *p, Arena &) {
+//              ^^^^^^^^ definition [..] InArena#`operator delete`(71e17451144c5c5c).
+//                                    ^ definition local 18
+//                                       ^^^^^ reference [..] Arena#
+      return ::operator delete(p);
+//             ^^^^^^^^ reference [..] `operator delete`(bd21765a0afc8e3c).
+//                             ^ reference local 18
+    }
+    static void operator delete[](void *p, Arena &) {
+//              ^^^^^^^^ definition [..] InArena#`operator delete[]`(71e17451144c5c5c).
+//                                      ^ definition local 19
+//                                         ^^^^^ reference [..] Arena#
+      return ::operator delete[](p);
+//             ^^^^^^^^ reference [..] `operator delete[]`(bd21765a0afc8e3c).
+//                               ^ reference local 19
+    }
+  };
+  
+  void test_new_delete() {
+//     ^^^^^^^^^^^^^^^ definition [..] test_new_delete(49f6e7a06ebc5aa8).
+    int *x = new int;
+//       ^ definition local 20
+    delete x;
+//         ^ reference local 20
+    int *xs = new int[4];
+//       ^^ definition local 21
+    delete[] xs;
+//           ^^ reference local 21
+  
+    Arena a{};
+//  ^^^^^ reference [..] Arena#
+//        ^ definition local 22
+    auto *p1 = new (a) InArena;
+//        ^^ definition local 23
+//                  ^ reference local 22
+//                     ^^^^^^^ reference [..] InArena#
+    delete p1;
+//         ^^ reference local 23
+    auto *p2 = new (a) InArena[3];
+//        ^^ definition local 24
+//                  ^ reference local 22
+//                     ^^^^^^^ reference [..] InArena#
+    delete[] p2;
+//           ^^ reference local 24
+  }
+  
+  // User-defined literals
+  
+  void operator ""_ull_lit(unsigned long long) { return; }
+//     ^^^^^^^^ definition [..] `operator""_ull_lit`(891dc3055356b409).
+  void operator ""_raw_lit(const char *) { return; }
+//     ^^^^^^^^ definition [..] `operator""_raw_lit`(85c52e162fed56f9).
+  
+  template <char...>
+  void operator""_templated_lit() {}
+//     ^^^^^^^^ definition [..] `operator""_templated_lit`(49f6e7a06ebc5aa8).
+  
+  struct A { constexpr A(const char *) {} };
+//       ^ definition [..] A#
+//                     ^ definition [..] A#A(85c52e162fed56f9).
+  
+  template <A a> // since C++20
+//          ^ reference [..] A#
+  void operator ""_a_op() { return; }
+//     ^^^^^^^^ definition [..] `operator""_a_op`(49f6e7a06ebc5aa8).
+  
+  void test_literals() {
+//     ^^^^^^^^^^^^^ definition [..] test_literals(49f6e7a06ebc5aa8).
+    123_ull_lit;
+//     ^^^^^^^^ reference [..] `operator""_ull_lit`(891dc3055356b409).
+    123_raw_lit;
+//     ^^^^^^^^ reference [..] `operator""_raw_lit`(85c52e162fed56f9).
+    123_templated_lit;
+//     ^^^^^^^^^^^^^^ reference [..] `operator""_templated_lit`(49f6e7a06ebc5aa8).
+    "123"_a_op; // invokes operator""_a_op<A("123")>
+  }
+  
+  // Overloaded co_await
+  // FIXME(issue: https://github.com/sourcegraph/scip-clang/issues/125)

--- a/test/index/namespaces/namespaces.snapshot.cc
+++ b/test/index/namespaces/namespaces.snapshot.cc
@@ -81,6 +81,7 @@
   }
   
   void f(a::c_alias::E) {
+//     ^ definition [..] f(5734375c1c12cb14).
 //       ^ reference [..] a/
 //                   ^ reference [..] a/c/E#
     (void)a::c::E::E0;

--- a/test/index/types/types.snapshot.cc
+++ b/test/index/types/types.snapshot.cc
@@ -94,10 +94,12 @@
 //               ^^ reference [..] F1#
   
     void f1(F1 *) { }
+//       ^^ definition [..] F0#f1(9e7252de2ffc92f6).
 //          ^^ reference [..] F1#
   };
   
   void f() {
+//     ^ definition [..] f(49f6e7a06ebc5aa8).
     class fC {
       void fCf() {
         class fCfC { };
@@ -137,6 +139,7 @@
 //               ^^ definition [..] E#E0.
   
   void f(GenericClass<E, int(E::E0)>) {
+//     ^ definition [..] f(a9a88f5fb6852c6b).
 //                    ^ reference [..] E#
 //                           ^ reference [..] E#
 //                              ^^ reference [..] E#E0.
@@ -177,6 +180,7 @@
   class CRTPBase {
 //      ^^^^^^^^ definition [..] CRTPBase#
     void castAndDoStuff() { static_cast<CRTPChild *>(this)->doStuff(); }
+//       ^^^^^^^^^^^^^^ definition [..] CRTPBase#castAndDoStuff(49f6e7a06ebc5aa8).
   };
   
   class CRTPChild: CRTPBase<CRTPChild> {
@@ -184,6 +188,7 @@
 //      relation implementation [..] CRTPBase#
 //                          ^^^^^^^^^ reference [..] CRTPChild#
     void doStuff() { }
+//       ^^^^^^^ definition [..] CRTPChild#doStuff(49f6e7a06ebc5aa8).
   };
   
   class DiamondBase {};

--- a/test/index/vars/k&r.snapshot.c
+++ b/test/index/vars/k&r.snapshot.c
@@ -1,4 +1,5 @@
   int these_violent_delights(x, y)
+//    ^^^^^^^^^^^^^^^^^^^^^^ definition [..] these_violent_delights(9b79fb6aee4c0440).
     int x;
 //      ^ definition local 0
     int y;

--- a/test/index/vars/vars.snapshot.cc
+++ b/test/index/vars/vars.snapshot.cc
@@ -3,10 +3,12 @@
   int MyGlobal = 3;
   
   int f(int x_, int y_);
+//    ^ reference [..] f(9b79fb6aee4c0440).
 //          ^^ definition local 0
 //                  ^^ definition local 1
   
   int f(int x, int y) {
+//    ^ definition [..] f(9b79fb6aee4c0440).
 //          ^ definition local 2
 //                 ^ definition local 3
     int z = x + y;
@@ -34,8 +36,10 @@
   };
   
   int f(S s) {
+//    ^ definition [..] f(6871c211ea8bb0a1).
 //      ^ reference [..] S#
 //        ^ definition local 8
     return s.x + S::y;
 //         ^ reference local 8
+//               ^ reference [..] S#
   }


### PR DESCRIPTION
TODO:
- [x] Add tests for methods, including inheritance, virtual methods etc.
- [x] Add test for member function pointer
- [x] Add tests for various kinds of operator overloads
- [x] Add is_reference and is_implementation relationships
- [x] Integration testing 

Follow-ups:
- References for explicit and implicit conversion functions: https://github.com/sourcegraph/scip-clang/issues/128
- References for operator new/delete https://github.com/sourcegraph/scip-clang/issues/127
- Definitions + references for constructors, with more tests https://github.com/sourcegraph/scip-clang/issues/126

I haven't added anything for template deduction guides, because AFAICT (I have not looked into it too deeply), you can't really reference one explicitly in code... They get examined by the compiler when doing CTAD, and that's about it...