### PR TITLE
fix: Replace canonical paths with StableFileId

### DIFF
--- a/indexer/Path.h
+++ b/indexer/Path.h
@@ -40,6 +40,10 @@ public:
 
   // Basic prefix-based implementation; does not handle lexical normalization.
   std::optional<std::string_view> makeRelative(AbsolutePathRef longerPath);
+
+  /// Try to get the file name by slicing off the prefix till the last
+  /// path separator.
+  std::optional<std::string_view> fileName() const;
 };
 
 /// Typically used when referring to paths for files which may or may not
@@ -123,6 +127,8 @@ public:
   RootRelativePath &operator=(const RootRelativePath &) = default;
 
   explicit RootRelativePath(RootRelativePathRef ref);
+
+  RootRelativePath(std::string &&, RootKind);
 
   const std::string &asStringRef() const {
     return this->value;


### PR DESCRIPTION
These provide a clearer way of signalling in-project
vs out-of-project files. For example, when we see
references in out-of-project files, we can skip emitting
them altogether.