### PR TITLE
refactor: Don't emit Occurrences for external files

### DIFF
--- a/indexer/Indexer.h
+++ b/indexer/Indexer.h
@@ -208,10 +208,11 @@ class TuIndexer final {
   SymbolFormatter &symbolFormatter;
   absl::flat_hash_map<llvm_ext::AbslHashAdapter<clang::FileID>, PartialDocument>
       documentMap;
+  GetStableFileId getStableFileId;
 
 public:
   TuIndexer(const clang::SourceManager &, const clang::LangOptions &,
-            const clang::ASTContext &, SymbolFormatter &);
+            const clang::ASTContext &, SymbolFormatter &, GetStableFileId);
 
   // See NOTE(ref: emit-vs-save) for naming conventions.
 #define SAVE_DECL(DeclName) \

--- a/indexer/Worker.cc
+++ b/indexer/Worker.cc
@@ -933,7 +933,8 @@ public:
     };
     SymbolFormatter symbolFormatter{sourceManager, getStableFileId};
     TuIndexer tuIndexer{sourceManager, this->sema->getLangOpts(),
-                        this->sema->getASTContext(), symbolFormatter};
+                        this->sema->getASTContext(), symbolFormatter,
+                        getStableFileId};
 
     IndexerAstVisitor visitor{stableFileIdMap, std::move(toBeIndexed),
                               this->options.deterministic, tuIndexer};


### PR DESCRIPTION
SCIP doesn't track Occurrences in project-external files, so check
if a file is external before emitting a definition/reference Occurrence.