### PR TITLE
feat: Infer the resource directory

### DIFF
--- a/indexer/Driver.cc
+++ b/indexer/Driver.cc
@@ -818,7 +818,10 @@ private:
         std::min(this->compdbCommandCount, this->numWorkers());
     spdlog::debug("total {} compilation jobs", this->compdbCommandCount);
 
-    this->compdbParser.initialize(compdbFile, this->refillCount());
+    // FIXME(def: resource-dir-extra): If we're passed in a resource dir
+    // as an extra argument, we should not pass it here.
+    this->compdbParser.initialize(compdbFile, this->refillCount(),
+                                  !this->options.isTesting);
     return FileGuard(compdbFile.file);
   }
 

--- a/indexer/Worker.cc
+++ b/indexer/Worker.cc
@@ -1115,7 +1115,8 @@ Worker::Worker(WorkerOptions &&options)
         this->options.compdbPath,
         compdb::ValidationOptions{.checkDirectoryPathsAreAbsolute = true});
     compdb::ResumableParser parser{};
-    parser.initialize(compdbFile, std::numeric_limits<size_t>::max());
+    // See FIXME(ref: resource-dir-extra)
+    parser.initialize(compdbFile, std::numeric_limits<size_t>::max(), true);
     parser.parseMore(this->compileCommands);
     std::fclose(compdbFile.file);
     break;

--- a/test/test_main.cc
+++ b/test/test_main.cc
@@ -139,7 +139,7 @@ TEST_CASE("COMPDB_PARSING") {
 
     for (auto refillCount : testCase.refillCountsToTry) {
       compdb::ResumableParser parser{};
-      parser.initialize(compdbFile, refillCount);
+      parser.initialize(compdbFile, refillCount, false);
       std::vector<std::vector<clang::tooling::CompileCommand>> commandGroups;
       std::string buffer;
       llvm::raw_string_ostream outStr(buffer);


### PR DESCRIPTION
This avoids needing to pass an extra -resource-dir manually,
which was documented in the lsif-clang instructions earlier.

Fixes #158
