### PR TITLE
debug: Weaken assertion around unseen headers

### DIFF
--- a/indexer/IpcMessages.h
+++ b/indexer/IpcMessages.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <compare>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -178,6 +179,10 @@ SERIALIZABLE(IndexingStatistics)
 struct ShardPaths {
   AbsolutePath docsAndExternals;
   AbsolutePath forwardDecls;
+
+  static std::string prefix(uint32_t taskId, WorkerId workerId);
+
+  static std::optional<uint32_t> tryParseJobId(std::string_view fileName);
 };
 SERIALIZABLE(ShardPaths)
 

--- a/indexer/Worker.cc
+++ b/indexer/Worker.cc
@@ -1380,10 +1380,9 @@ Worker::ReceiveStatus Worker::processTranslationUnitAndRespond(
     return ReceiveStatus::OK;
   }
 
-  StdPath prefix =
-      this->options.temporaryOutputDir
-      / fmt::format("job-{}-worker-{}", emitIndexRequestId.taskId(),
-                    this->ipcOptions().workerId);
+  StdPath prefix = this->options.temporaryOutputDir
+                   / ShardPaths::prefix(emitIndexRequestId.taskId(),
+                                        this->ipcOptions().workerId);
   StdPath docsAndExternalsOutputPath =
       prefix.concat("-docs_and_externals.shard.scip");
   StdPath forwardDeclsOutputPath = prefix.concat("-forward_decls.shard.scip");


### PR DESCRIPTION
A customer ran into an ENFORCE around unknown headers,
but it's not clear in what situations that's possible.
Added some debug logging for now and weakened the assertion.

Workaround for #193