### PR TITLE
fix: Try setting -working-directory too

### DIFF
--- a/indexer/Worker.cc
+++ b/indexer/Worker.cc
@@ -201,6 +201,8 @@ void Worker::processTranslationUnit(SemanticAnalysisJobDetails &&job,
   auto args = std::move(job.command.CommandLine);
   args.push_back("-fsyntax-only");   // Only type-checking, no codegen.
   args.push_back("-Wno-everything"); // Warnings aren't helpful.
+  args.push_back("-working-directory");
+  args.push_back(fileSystemOptions.WorkingDir);
   // clang-format off
   // TODO(def: flag-passthrough, issue: https://github.com/sourcegraph/scip-clang/issues/23)
   // Support passing through CLI flags to Clang, similar to --extra-arg in lsif-clang


### PR DESCRIPTION
For unclear reasons, setting the `WorkingDir` field on `fileSystemOptions`
is insufficient. Without this, scip-clang fails to locate a "system" header
without it.

```
In file included from ../../apps/app_lifetime_monitor.cc:5:
In file included from ../../apps/app_lifetime_monitor.h:8:
In file included from ../../buildtools/third_party/libc++/trunk/include/string:537:
In file included from ../../buildtools/third_party/libc++/trunk/include/__algorithm/max.h:12:
In file included from ../../buildtools/third_party/libc++/trunk/include/__algorithm/comp.h:12:
In file included from ../../buildtools/third_party/libc++/trunk/include/__config:279:
../../build/linux/debian_bullseye_amd64-sysroot/usr/include/features.h:461:12: fatal error: 'sys/cdefs.h' file not found
#  include <sys/cdefs.h>
           ^~~~~~~~~~~~~
1 error generated.
```