### PR TITLE
build: Stop detecting host C++ toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,7 @@ build --cxxopt="-std=c++20" --host_cxxopt="-std=c++20" --client_env=BAZEL_CXXOPT
 # Per grailbio/bazel-toolchain docs
 build --incompatible_enable_cc_toolchain_resolution
 
+build --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 
 build --@llvm_zstd//:llvm_enable_zstd=false
 
 build --copt="-Wall" --copt="-Wextra" --copt="-Wwrite-strings" --copt="-Wcast-qual" --copt="-Wmissing-field-initializers" --copt="-Wimplicit-fallthrough" --copt="-Wcovered-switch-default" --copt="-Wsuggest-override" --copt="-Wstring-concatenation" --copt="-Wstring-conversion" --copt="-Wmisleading-indentation"


### PR DESCRIPTION
This allows builds to work on Linux without having a host
C++ toolchain, making things a bit simpler when working
inside a VM. It should also make builds a tiny bit faster.
