### PR TITLE
fix: Use unsubstituted types for disambiguators

### DIFF
--- a/indexer/SymbolFormatter.cc
+++ b/indexer/SymbolFormatter.cc
@@ -406,12 +406,31 @@ SymbolFormatter::getFunctionSymbol(const clang::FunctionDecl &functionDecl) {
           return {};
         }
         const clang::FunctionDecl *definingDecl = &functionDecl;
+        // clang-format off
         if (functionDecl.isTemplateInstantiation()) {
-          if (auto *memberFnDecl =
-                  functionDecl.getInstantiatedFromMemberFunction()) {
+          // Handle non-templated member functions
+          if (auto *memberFnDecl = functionDecl.getInstantiatedFromMemberFunction()) {
             definingDecl = memberFnDecl;
+          } else if (auto *templateInfo = functionDecl.getTemplateSpecializationInfo()) {
+            // Consider code like:
+            //   template <typename T> class C { template <typename U> void f() {} };
+            //   void g() { C<int>().f<int>(); }
+            //                       ^ Emitting a reference
+            //
+            // The dance below gets to the original declaration in 3 steps:
+            // C<int>.f<int> (FunctionDecl) → C<int>.f<$U> (FunctionTemplateDecl)
+            //                                     ↓
+            // C<$T>.f<$U>   (FunctionDecl) ← C<$T>.f<$U>  (FunctionTemplateDecl)
+            auto *instantiatedTemplateDecl = templateInfo->getTemplate();
+            // For some reason, we end up on this code path for overloaded
+            // literal operators. In that case, uninstantiatedTemplateDecl
+            // can be null.
+            if (auto *uninstantiatedTemplateDecl = instantiatedTemplateDecl->getInstantiatedFromMemberTemplate()) {
+              definingDecl = uninstantiatedTemplateDecl->getTemplatedDecl();
+            }
           }
         }
+        // clang-format on
         auto name = this->formatTemporary(functionDecl);
         // 64-bit hash in hex should take 16 characters at most.
         auto typeString =

--- a/indexer/SymbolFormatter.cc
+++ b/indexer/SymbolFormatter.cc
@@ -407,7 +407,8 @@ SymbolFormatter::getFunctionSymbol(const clang::FunctionDecl &functionDecl) {
         }
         const clang::FunctionDecl *definingDecl = &functionDecl;
         if (functionDecl.isTemplateInstantiation()) {
-          if (auto *memberFnDecl = functionDecl.getInstantiatedFromMemberFunction()) {
+          if (auto *memberFnDecl =
+                  functionDecl.getInstantiatedFromMemberFunction()) {
             definingDecl = memberFnDecl;
           }
         }
@@ -419,12 +420,11 @@ SymbolFormatter::getFunctionSymbol(const clang::FunctionDecl &functionDecl) {
         auto *end = fmt::format_to(buf, "{:x}", HashValue::forText(typeString));
         std::string_view disambiguator{buf, end};
         return SymbolBuilder::formatContextual(
-            optContextSymbol.value(),
-            DescriptorBuilder{
-                .name = name,
-                .disambiguator = disambiguator,
-                .suffix = scip::Descriptor::Method,
-            });
+            optContextSymbol.value(), DescriptorBuilder{
+                                          .name = name,
+                                          .disambiguator = disambiguator,
+                                          .suffix = scip::Descriptor::Method,
+                                      });
       });
 }
 

--- a/test/index/functions/methods.cc
+++ b/test/index/functions/methods.cc
@@ -75,22 +75,3 @@ void test_member_pointer() {
   M0 m{};
   (m.*p)();
 }
-
-template <typename T>
-struct T0 {
-  void f0() {}
-};
-
-template <typename T>
-struct T1: T0<T> {
-  void f1() {
-    this->f0();
-  }
-};
-
-void test_template() {
-  T0<int>().f0();
-  T1<int>().f1();
-  auto t1 = T1<int>();
-  t1.f0();
-}

--- a/test/index/functions/methods.snapshot.cc
+++ b/test/index/functions/methods.snapshot.cc
@@ -165,39 +165,3 @@
 //   ^ reference local 1
 //      ^ reference local 0
   }
-  
-  template <typename T>
-//                   ^ definition local 2
-  struct T0 {
-//       ^^ definition [..] T0#
-    void f0() {}
-//       ^^ definition [..] T0#f0(49f6e7a06ebc5aa8).
-  };
-  
-  template <typename T>
-//                   ^ definition local 3
-  struct T1: T0<T> {
-//       ^^ definition [..] T1#
-//           ^^ reference [..] T0#
-//              ^ reference local 3
-    void f1() {
-//       ^^ definition [..] T1#f1(49f6e7a06ebc5aa8).
-      this->f0();
-    }
-  };
-  
-  void test_template() {
-//     ^^^^^^^^^^^^^ definition [..] test_template(49f6e7a06ebc5aa8).
-    T0<int>().f0();
-//  ^^ reference [..] T0#
-//            ^^ reference [..] T0#f0(49f6e7a06ebc5aa8).
-    T1<int>().f1();
-//  ^^ reference [..] T1#
-//            ^^ reference [..] T1#f1(49f6e7a06ebc5aa8).
-    auto t1 = T1<int>();
-//       ^^ definition local 4
-//            ^^ reference [..] T1#
-    t1.f0();
-//  ^^ reference local 4
-//     ^^ reference [..] T0#f0(49f6e7a06ebc5aa8).
-  }

--- a/test/index/functions/templates.cc
+++ b/test/index/functions/templates.cc
@@ -1,0 +1,42 @@
+template <typename T>
+struct T0 {
+  void f0(T) {}
+
+  template <typename U>
+  void g0(U) {}
+};
+
+template <typename T>
+struct T1: T0<T> {
+  void f1(T t) {
+    this->f0(t);
+  }
+
+  template <typename U>
+  void g1(U u) {
+    this->template g0<U>(u);
+  }
+};
+
+template <typename H>
+void h0(H) {}
+
+template <typename H>
+void h1(H h) { h0<H>(h); }
+
+void test_template() {
+  T0<int>().f0(0);
+  T1<int>().f1(0);
+  auto t1 = T1<int>();
+  t1.f0(0);
+
+  T0<int>().g0<int>(0);
+  T1<int>().g1<unsigned>(0);
+  auto t1_ = T1<int>();
+  t1_.g0<char>(0);
+
+  h0<int>(0);
+  h0<void *>(0);
+  h1<int>(0);
+  h1<char>(0);
+}

--- a/test/index/functions/templates.snapshot.cc
+++ b/test/index/functions/templates.snapshot.cc
@@ -59,16 +59,16 @@
 //     ^^^^^^^^^^^^^ definition [..] test_template(49f6e7a06ebc5aa8).
     T0<int>().f0(0);
 //  ^^ reference [..] T0#
-//            ^^ reference [..] T0#f0(d4f767463ce0a6b3).
+//            ^^ reference [..] T0#f0(9b289cee16747614).
     T1<int>().f1(0);
 //  ^^ reference [..] T1#
-//            ^^ reference [..] T1#f1(d4f767463ce0a6b3).
+//            ^^ reference [..] T1#f1(9b289cee16747614).
     auto t1 = T1<int>();
 //       ^^ definition local 9
 //            ^^ reference [..] T1#
     t1.f0(0);
 //  ^^ reference local 9
-//     ^^ reference [..] T0#f0(d4f767463ce0a6b3).
+//     ^^ reference [..] T0#f0(9b289cee16747614).
   
     T0<int>().g0<int>(0);
 //  ^^ reference [..] T0#

--- a/test/index/functions/templates.snapshot.cc
+++ b/test/index/functions/templates.snapshot.cc
@@ -72,16 +72,16 @@
   
     T0<int>().g0<int>(0);
 //  ^^ reference [..] T0#
-//            ^^ reference [..] T0#g0(d4f767463ce0a6b3).
+//            ^^ reference [..] T0#g0(b07662a27bd562f9).
     T1<int>().g1<unsigned>(0);
 //  ^^ reference [..] T1#
-//            ^^ reference [..] T1#g1(cb2f890c2fdad230).
+//            ^^ reference [..] T1#g1(b07662a27bd562f9).
     auto t1_ = T1<int>();
 //       ^^^ definition local 10
 //             ^^ reference [..] T1#
     t1_.g0<char>(0);
 //  ^^^ reference local 10
-//      ^^ reference [..] T0#g0(44b6ea1973a07080).
+//      ^^ reference [..] T0#g0(b07662a27bd562f9).
   
     h0<int>(0);
     h0<void *>(0);

--- a/test/index/functions/templates.snapshot.cc
+++ b/test/index/functions/templates.snapshot.cc
@@ -1,0 +1,90 @@
+  template <typename T>
+//^^^^^^^^ definition [..] `<file>/templates.cc`/
+//                   ^ definition local 0
+  struct T0 {
+//       ^^ definition [..] T0#
+    void f0(T) {}
+//       ^^ definition [..] T0#f0(9b289cee16747614).
+//          ^ reference local 0
+  
+    template <typename U>
+//                     ^ definition local 1
+    void g0(U) {}
+//       ^^ definition [..] T0#g0(b07662a27bd562f9).
+//          ^ reference local 1
+  };
+  
+  template <typename T>
+//                   ^ definition local 2
+  struct T1: T0<T> {
+//       ^^ definition [..] T1#
+//           ^^ reference [..] T0#
+//              ^ reference local 2
+    void f1(T t) {
+//       ^^ definition [..] T1#f1(9b289cee16747614).
+//          ^ reference local 2
+//            ^ definition local 3
+      this->f0(t);
+//             ^ reference local 3
+    }
+  
+    template <typename U>
+//                     ^ definition local 4
+    void g1(U u) {
+//       ^^ definition [..] T1#g1(b07662a27bd562f9).
+//          ^ reference local 4
+//            ^ definition local 5
+      this->template g0<U>(u);
+//                      ^ reference local 4
+//                         ^ reference local 5
+    }
+  };
+  
+  template <typename H>
+//                   ^ definition local 6
+  void h0(H) {}
+//     ^^ definition [..] h0(9b289cee16747614).
+//        ^ reference local 6
+  
+  template <typename H>
+//                   ^ definition local 7
+  void h1(H h) { h0<H>(h); }
+//     ^^ definition [..] h1(9b289cee16747614).
+//        ^ reference local 7
+//          ^ definition local 8
+//                  ^ reference local 7
+//                     ^ reference local 8
+  
+  void test_template() {
+//     ^^^^^^^^^^^^^ definition [..] test_template(49f6e7a06ebc5aa8).
+    T0<int>().f0(0);
+//  ^^ reference [..] T0#
+//            ^^ reference [..] T0#f0(d4f767463ce0a6b3).
+    T1<int>().f1(0);
+//  ^^ reference [..] T1#
+//            ^^ reference [..] T1#f1(d4f767463ce0a6b3).
+    auto t1 = T1<int>();
+//       ^^ definition local 9
+//            ^^ reference [..] T1#
+    t1.f0(0);
+//  ^^ reference local 9
+//     ^^ reference [..] T0#f0(d4f767463ce0a6b3).
+  
+    T0<int>().g0<int>(0);
+//  ^^ reference [..] T0#
+//            ^^ reference [..] T0#g0(d4f767463ce0a6b3).
+    T1<int>().g1<unsigned>(0);
+//  ^^ reference [..] T1#
+//            ^^ reference [..] T1#g1(cb2f890c2fdad230).
+    auto t1_ = T1<int>();
+//       ^^^ definition local 10
+//             ^^ reference [..] T1#
+    t1_.g0<char>(0);
+//  ^^^ reference local 10
+//      ^^ reference [..] T0#g0(44b6ea1973a07080).
+  
+    h0<int>(0);
+    h0<void *>(0);
+    h1<int>(0);
+    h1<char>(0);
+  }


### PR DESCRIPTION
At the moment, we use substituted types for disambiguators.
This means that if you have a templated method with "type"

```
<T>(T) -> void
```

Then different instantiations will have different disambiguators,
causing code nav to break, as there is no fallback based on
disambiguator-irrelevant matching. We should try to use the unsubstituted
type if possible.

TODO:
- [x] Non-templated member functions in templated classes
- [x] Templated member functions in templated classes