### PR TITLE
fix: Emit defs/refs for function-local types

### DIFF
--- a/indexer/SymbolFormatter.cc
+++ b/indexer/SymbolFormatter.cc
@@ -246,10 +246,11 @@ std::optional<std::string_view> SymbolFormatter::getSymbolCached(
 
 std::optional<std::string_view>
 SymbolFormatter::getContextSymbol(const clang::DeclContext &declContext) {
-  if (auto namespaceDecl = llvm::dyn_cast<clang::NamespaceDecl>(&declContext)) {
+  if (auto *namespaceDecl =
+          llvm::dyn_cast<clang::NamespaceDecl>(&declContext)) {
     return this->getNamespaceSymbol(*namespaceDecl);
   }
-  if (auto tagDecl = llvm::dyn_cast<clang::TagDecl>(&declContext)) {
+  if (auto *tagDecl = llvm::dyn_cast<clang::TagDecl>(&declContext)) {
     return this->getTagSymbol(*tagDecl);
   }
   if (llvm::isa<clang::TranslationUnitDecl>(declContext)
@@ -264,16 +265,22 @@ SymbolFormatter::getContextSymbol(const clang::DeclContext &declContext) {
       return std::string(this->scratchBuffer);
     });
   }
+  if (auto *functionDecl = llvm::dyn_cast<clang::FunctionDecl>(&declContext)) {
+    // TODO: Strictly speaking, we should return some information marking
+    // the symbol as local, but it shouldn't be possible to create spurious
+    // references, so this is OK for now.
+    return this->getFunctionSymbol(*functionDecl);
+  }
   // TODO: Handle all cases of DeclContext here:
   // Done
   // - TranslationUnitDecl
   // - ExternCContext
   // - NamespaceDecl
   // - TagDecl
+  // - FunctionDecl
   // Pending:
   // - OMPDeclareReductionDecl
   // - OMPDeclareMapperDecl
-  // - FunctionDecl
   // - ObjCMethodDecl
   // - ObjCContainerDecl
   // - LinkageSpecDecl

--- a/test/index/functions/body.cc
+++ b/test/index/functions/body.cc
@@ -1,0 +1,13 @@
+void f() {
+  struct C {
+    int plain_field;
+
+    void g() {};
+  };
+
+  (void)C().plain_field;
+  C().g();
+
+  int x = 0;
+  (void)(2 * x);
+}

--- a/test/index/functions/body.snapshot.cc
+++ b/test/index/functions/body.snapshot.cc
@@ -1,0 +1,24 @@
+  void f() {
+//^^^^ definition [..] `<file>/body.cc`/
+//     ^ definition [..] f(49f6e7a06ebc5aa8).
+    struct C {
+//         ^ definition [..] f(49f6e7a06ebc5aa8).C#
+      int plain_field;
+//        ^^^^^^^^^^^ definition [..] f(49f6e7a06ebc5aa8).C#plain_field.
+  
+      void g() {};
+//         ^ definition [..] f(49f6e7a06ebc5aa8).C#g(49f6e7a06ebc5aa8).
+    };
+  
+    (void)C().plain_field;
+//        ^ reference [..] f(49f6e7a06ebc5aa8).C#
+//            ^^^^^^^^^^^ reference [..] f(49f6e7a06ebc5aa8).C#plain_field.
+    C().g();
+//  ^ reference [..] f(49f6e7a06ebc5aa8).C#
+//      ^ reference [..] f(49f6e7a06ebc5aa8).C#g(49f6e7a06ebc5aa8).
+  
+    int x = 0;
+//      ^ definition local 0
+    (void)(2 * x);
+//             ^ reference local 0
+  }

--- a/test/index/functions/template_body.cc
+++ b/test/index/functions/template_body.cc
@@ -1,0 +1,18 @@
+template <typename T>
+void f() {
+  struct C {
+    T field;
+
+    void g() {};
+  };
+
+  auto t = C().field;
+  C().g();
+
+  int x = 0;
+  (void)(2 * x);
+
+  // The following are not allowed:
+  // - Templated function-local classes
+  // - Templates inside function-local classes
+}

--- a/test/index/functions/template_body.cc
+++ b/test/index/functions/template_body.cc
@@ -1,12 +1,14 @@
 template <typename T>
 void f() {
   struct C {
-    T field;
+    int plain_field;
+    T dependent_field;
 
     void g() {};
   };
 
-  auto t = C().field;
+  (void)C().plain_field;
+  (void)C().dependent_field;
   C().g();
 
   int x = 0;

--- a/test/index/functions/template_body.snapshot.cc
+++ b/test/index/functions/template_body.snapshot.cc
@@ -4,15 +4,20 @@
   void f() {
 //     ^ definition [..] f(49f6e7a06ebc5aa8).
     struct C {
+//         ^ definition [..] f(49f6e7a06ebc5aa8).C#
       T field;
 //    ^ reference local 0
+//      ^^^^^ definition [..] f(49f6e7a06ebc5aa8).C#field.
   
       void g() {};
+//         ^ definition [..] f(49f6e7a06ebc5aa8).C#g(49f6e7a06ebc5aa8).
     };
   
     auto t = C().field;
 //       ^ definition local 1
+//           ^ reference [..] f(49f6e7a06ebc5aa8).C#
     C().g();
+//  ^ reference [..] f(49f6e7a06ebc5aa8).C#
   
     int x = 0;
 //      ^ definition local 2

--- a/test/index/functions/template_body.snapshot.cc
+++ b/test/index/functions/template_body.snapshot.cc
@@ -1,0 +1,25 @@
+  template <typename T>
+//^^^^^^^^ definition [..] `<file>/template_body.cc`/
+//                   ^ definition local 0
+  void f() {
+//     ^ definition [..] f(49f6e7a06ebc5aa8).
+    struct C {
+      T field;
+//    ^ reference local 0
+  
+      void g() {};
+    };
+  
+    auto t = C().field;
+//       ^ definition local 1
+    C().g();
+  
+    int x = 0;
+//      ^ definition local 2
+    (void)(2 * x);
+//             ^ reference local 2
+  
+    // The following are not allowed:
+    // - Templated function-local classes
+    // - Templates inside function-local classes
+  }

--- a/test/index/functions/template_body.snapshot.cc
+++ b/test/index/functions/template_body.snapshot.cc
@@ -5,24 +5,27 @@
 //     ^ definition [..] f(49f6e7a06ebc5aa8).
     struct C {
 //         ^ definition [..] f(49f6e7a06ebc5aa8).C#
-      T field;
+      int plain_field;
+//        ^^^^^^^^^^^ definition [..] f(49f6e7a06ebc5aa8).C#plain_field.
+      T dependent_field;
 //    ^ reference local 0
-//      ^^^^^ definition [..] f(49f6e7a06ebc5aa8).C#field.
+//      ^^^^^^^^^^^^^^^ definition [..] f(49f6e7a06ebc5aa8).C#dependent_field.
   
       void g() {};
 //         ^ definition [..] f(49f6e7a06ebc5aa8).C#g(49f6e7a06ebc5aa8).
     };
   
-    auto t = C().field;
-//       ^ definition local 1
-//           ^ reference [..] f(49f6e7a06ebc5aa8).C#
+    (void)C().plain_field;
+//        ^ reference [..] f(49f6e7a06ebc5aa8).C#
+    (void)C().dependent_field;
+//        ^ reference [..] f(49f6e7a06ebc5aa8).C#
     C().g();
 //  ^ reference [..] f(49f6e7a06ebc5aa8).C#
   
     int x = 0;
-//      ^ definition local 2
+//      ^ definition local 1
     (void)(2 * x);
-//             ^ reference local 2
+//             ^ reference local 1
   
     // The following are not allowed:
     // - Templated function-local classes

--- a/test/index/types/types.snapshot.cc
+++ b/test/index/types/types.snapshot.cc
@@ -157,8 +157,17 @@
 //     documentation
 //     | No documentation available.
     class fC {
+//        ^^ definition [..] f(49f6e7a06ebc5aa8).fC#
+//        documentation
+//        | No documentation available.
       void fCf() {
+//         ^^^ definition [..] f(49f6e7a06ebc5aa8).fC#fCf(49f6e7a06ebc5aa8).
+//         documentation
+//         | No documentation available.
         class fCfC { };
+//            ^^^^ definition [..] f(49f6e7a06ebc5aa8).fC#fCf(49f6e7a06ebc5aa8).fCfC#
+//            documentation
+//            | No documentation available.
       }
     };
   }
@@ -332,5 +341,6 @@
     };
     return ignore_first("", L{});
 //         ^^^^^^^^^^^^ reference local 3
+//                     ^ reference [..] trailing_return_type(693bfa61ed1914d5).$anonymous_type_4#`operator()`(dc97d1a1ce4cdab3).
 //                          ^ reference [..] L#
   }


### PR DESCRIPTION
At the moment, we're still not emitting defs and refs for dependent expressions,
because it seems like they're unresolved in the AST. I need to look at what
clangd is doing here, because it does support code navigation for such expressions.