### PR TITLE
fix: Emit references for dependent members

### DIFF
--- a/indexer/ClangAstMacros.h
+++ b/indexer/ClangAstMacros.h
@@ -27,7 +27,8 @@
   F(CXXConstruct)                      \
   F(CXXDependentScopeMember)           \
   F(DeclRef)                           \
-  F(Member)
+  F(Member)                            \
+  F(UnresolvedMember)
 
 #define FOR_EACH_TYPE_TO_BE_INDEXED(F) \
   F(Enum)                              \

--- a/indexer/ClangAstMacros.h
+++ b/indexer/ClangAstMacros.h
@@ -25,6 +25,7 @@
 
 #define FOR_EACH_EXPR_TO_BE_INDEXED(F) \
   F(CXXConstruct)                      \
+  F(CXXDependentScopeMember)           \
   F(DeclRef)                           \
   F(Member)
 

--- a/indexer/Indexer.cc
+++ b/indexer/Indexer.cc
@@ -855,7 +855,8 @@ void TuIndexer::trySaveMemberReferenceViaLookup(
   if (!recordDecl) {
     return;
   }
-  // FIXME(): We should try to use more standard code which takes
+  // FIXME(issue: https://github.com/sourcegraph/scip-clang/issues/296):
+  // We should try to use more standard code which takes
   // inheritance into account.
   auto lookupResult = recordDecl->lookup(memberNameInfo.getName());
   for (auto *namedDecl : lookupResult) {

--- a/indexer/Indexer.cc
+++ b/indexer/Indexer.cc
@@ -788,6 +788,20 @@ void TuIndexer::saveCXXConstructExpr(
   }
 }
 
+void TuIndexer::saveCXXDependentScopeMemberExpr(const clang::CXXDependentScopeMemberExpr &cxxDepScopeMemberExpr) {
+  auto baseType = cxxDepScopeMemberExpr.getBaseType();
+  if (auto *tagType = baseType->getAs<clang::TagType>()) {
+    auto memberNameInfo = cxxDepScopeMemberExpr.getMemberNameInfo();
+    auto lookupResult = tagType->getDecl()->lookup(memberNameInfo.getName());
+    for (auto *namedDecl: lookupResult) {
+      auto optSymbol = this->symbolFormatter.getNamedDeclSymbol(*namedDecl);
+      if (optSymbol) {
+        this->saveReference(*optSymbol, memberNameInfo.getLoc());
+      }
+    }
+  }
+}
+
 void TuIndexer::saveDeclRefExpr(const clang::DeclRefExpr &declRefExpr) {
   // In the presence of 'using', prefer going to the 'using' instead
   // of directly dereferencing.

--- a/indexer/Indexer.h
+++ b/indexer/Indexer.h
@@ -35,6 +35,7 @@ FOR_EACH_TYPE_TO_BE_INDEXED(FORWARD_DECLARE)
 
 class ASTContext;
 class Decl;
+class DeclarationNameInfo;
 class LangOptions;
 class MacroDefinition;
 class MacroInfo;
@@ -269,6 +270,8 @@ public:
   FOR_EACH_EXPR_TO_BE_INDEXED(SAVE_EXPR)
 #undef SAVE_EXPR
   void saveNestedNameSpecifierLoc(const clang::NestedNameSpecifierLoc &);
+  void trySaveMemberReferenceViaLookup(const clang::QualType &,
+                                       const clang::DeclarationNameInfo &);
 
 #define SAVE_TYPE_LOC(TypeName) \
   void save##TypeName##TypeLoc(const clang::TypeName##TypeLoc &);

--- a/test/index/functions/template_body.cc
+++ b/test/index/functions/template_body.cc
@@ -18,3 +18,22 @@ void f() {
   // - Templated function-local classes
   // - Templates inside function-local classes
 }
+
+template <typename T>
+struct Z {
+  void f0() {}
+
+  void f1() {
+    f0();
+  }
+
+  template <typename U>
+  void g0() {
+    f0();
+  }
+
+  template <typename U>
+  void g1() {
+    g0<U>();
+  }
+};

--- a/test/index/functions/template_body.cc
+++ b/test/index/functions/template_body.cc
@@ -37,3 +37,16 @@ struct Z {
     g0<U>();
   }
 };
+
+template <typename T>
+struct ZZ : Z<T> {
+  void ff0() {
+    this->f0();
+  }
+
+  template <typename U>
+  void gg0() {
+    this->f0();
+    this->template g0<U>();
+  }
+};

--- a/test/index/functions/template_body.snapshot.cc
+++ b/test/index/functions/template_body.snapshot.cc
@@ -61,6 +61,7 @@
     void g1() {
 //       ^^ definition [..] Z#g1(49f6e7a06ebc5aa8).
       g0<U>();
+//    ^^ reference [..] Z#g0(49f6e7a06ebc5aa8).
 //       ^ reference local 4
     }
   };

--- a/test/index/functions/template_body.snapshot.cc
+++ b/test/index/functions/template_body.snapshot.cc
@@ -17,10 +17,13 @@
   
     (void)C().plain_field;
 //        ^ reference [..] f(49f6e7a06ebc5aa8).C#
+//            ^^^^^^^^^^^ reference [..] f(49f6e7a06ebc5aa8).C#plain_field.
     (void)C().dependent_field;
 //        ^ reference [..] f(49f6e7a06ebc5aa8).C#
+//            ^^^^^^^^^^^^^^^ reference [..] f(49f6e7a06ebc5aa8).C#dependent_field.
     C().g();
 //  ^ reference [..] f(49f6e7a06ebc5aa8).C#
+//      ^ reference [..] f(49f6e7a06ebc5aa8).C#g(49f6e7a06ebc5aa8).
   
     int x = 0;
 //      ^ definition local 1

--- a/test/index/functions/template_body.snapshot.cc
+++ b/test/index/functions/template_body.snapshot.cc
@@ -31,3 +31,33 @@
     // - Templated function-local classes
     // - Templates inside function-local classes
   }
+  
+  template <typename T>
+//                   ^ definition local 2
+  struct Z {
+//       ^ definition [..] Z#
+    void f0() {}
+//       ^^ definition [..] Z#f0(49f6e7a06ebc5aa8).
+  
+    void f1() {
+//       ^^ definition [..] Z#f1(49f6e7a06ebc5aa8).
+      f0();
+//    ^^ reference [..] Z#f0(49f6e7a06ebc5aa8).
+    }
+  
+    template <typename U>
+//                     ^ definition local 3
+    void g0() {
+//       ^^ definition [..] Z#g0(49f6e7a06ebc5aa8).
+      f0();
+//    ^^ reference [..] Z#f0(49f6e7a06ebc5aa8).
+    }
+  
+    template <typename U>
+//                     ^ definition local 4
+    void g1() {
+//       ^^ definition [..] Z#g1(49f6e7a06ebc5aa8).
+      g0<U>();
+//       ^ reference local 4
+    }
+  };

--- a/test/index/functions/template_body.snapshot.cc
+++ b/test/index/functions/template_body.snapshot.cc
@@ -64,3 +64,24 @@
 //       ^ reference local 4
     }
   };
+  
+  template <typename T>
+//                   ^ definition local 5
+  struct ZZ : Z<T> {
+//       ^^ definition [..] ZZ#
+//            ^ reference [..] Z#
+//              ^ reference local 5
+    void ff0() {
+//       ^^^ definition [..] ZZ#ff0(49f6e7a06ebc5aa8).
+      this->f0();
+    }
+  
+    template <typename U>
+//                     ^ definition local 6
+    void gg0() {
+//       ^^^ definition [..] ZZ#gg0(49f6e7a06ebc5aa8).
+      this->f0();
+      this->template g0<U>();
+//                      ^ reference local 6
+    }
+  };


### PR DESCRIPTION
Partly addresses #293. This doesn't handle lookup into related
semantic contexts. I tried `collectAllContexts` and iterating over
the results, but that didn't seem to do the trick. I'll file a separate
issue for the general case.