### PR TITLE
fix: Skip UsingDecls in name lookup

### DIFF
--- a/indexer/Indexer.cc
+++ b/indexer/Indexer.cc
@@ -857,9 +857,11 @@ void TuIndexer::trySaveMemberReferenceViaLookup(
   if (!recordDecl) {
     return;
   }
+  // Filter out UsingDecl as the corresponding UsingShadowDecl is sufficient.
   auto lookupResult = recordDecl->lookupDependentName(
-      memberNameInfo.getName(),
-      [](const clang::NamedDecl *) -> bool { return true; });
+      memberNameInfo.getName(), [&](const clang::NamedDecl *decl) -> bool {
+        return !llvm::isa<clang::UsingDecl>(decl);
+      });
   for (auto *namedDecl : lookupResult) {
     auto optSymbol = this->symbolFormatter.getNamedDeclSymbol(*namedDecl);
     if (optSymbol) {

--- a/test/index/aliases/aliases.cc
+++ b/test/index/aliases/aliases.cc
@@ -57,3 +57,22 @@ void g() {
   using enum LongLongEnum;
   using enum h::EvenLongerEnum;
 }
+
+namespace z {
+  struct U {
+    template <typename T>
+    T identity(T t) { return t; }
+  };
+
+  struct V: U {
+    int identity(int t, int) { return t; }
+    using U::identity;
+  };
+
+  template <typename T>
+  struct W {
+    V v;
+
+    T identity(T t) { return v.identity<T>(t); }
+  };
+}

--- a/test/index/aliases/aliases.snapshot.cc
+++ b/test/index/aliases/aliases.snapshot.cc
@@ -117,3 +117,49 @@
 //             ^ reference [..] h/
 //                ^^^^^^^^^^^^^^ reference [..] h/EvenLongerEnum#
   }
+  
+  namespace z {
+//          ^ definition [..] z/
+    struct U {
+//         ^ definition [..] z/U#
+      template <typename T>
+//                       ^ definition local 2
+      T identity(T t) { return t; }
+//    ^ reference local 2
+//      ^^^^^^^^ definition [..] z/U#identity(ada6a8422704cf8a).
+//               ^ reference local 2
+//                 ^ definition local 3
+//                             ^ reference local 3
+    };
+  
+    struct V: U {
+//         ^ definition [..] z/V#
+//         relation implementation [..] z/U#
+//            ^ reference [..] z/U#
+      int identity(int t, int) { return t; }
+//        ^^^^^^^^ definition [..] z/V#identity(9b79fb6aee4c0440).
+//                     ^ definition local 4
+//                                      ^ reference local 4
+      using U::identity;
+//          ^ reference [..] z/U#
+    };
+  
+    template <typename T>
+//                     ^ definition local 5
+    struct W {
+//         ^ definition [..] z/W#
+      V v;
+//    ^ reference [..] z/V#
+//      ^ definition [..] z/W#v.
+  
+      T identity(T t) { return v.identity<T>(t); }
+//    ^ reference local 5
+//      ^^^^^^^^ definition [..] z/W#identity(ada6a8422704cf8a).
+//               ^ reference local 5
+//                 ^ definition local 6
+//                             ^ reference [..] z/W#v.
+//                               ^^^^^^^^ reference [..] z/V#identity(9b79fb6aee4c0440).
+//                                        ^ reference local 5
+//                                           ^ reference local 6
+    };
+  }


### PR DESCRIPTION
This triggered an ENFORCE in the SymbolFormatter because
it doesn't expect to produce symbols for UsingDecls.
Getting the UsingDecl is unnecessary anyways since the
corresponding UsingShadowDecl is also present in the
lookup results.
