### PR TITLE
refactor: Use separate types for symbol names

### DIFF
--- a/indexer/ScipExtras.h
+++ b/indexer/ScipExtras.h
@@ -20,6 +20,7 @@
 #include "indexer/Derive.h"
 #include "indexer/Enforce.h"
 #include "indexer/RAII.h"
+#include "indexer/SymbolName.h"
 
 namespace scip {
 
@@ -112,24 +113,6 @@ public:
     this->_bomb.defuse();
   }
   void finish(bool deterministic, scip::SymbolInformation &out);
-};
-
-class SymbolName {
-  std::string value;
-
-  // The implicitly synthesized copy constructor is important as this is
-  // used a map key, which are required to be copy-constructible.
-public:
-  SymbolName(std::string &&value) : value(std::move(value)) {
-    ENFORCE(!this->value.empty());
-  }
-  const std::string &asStringRef() const {
-    return this->value;
-  }
-  std::string &asStringRefMut() {
-    return this->value;
-  }
-  DERIVE_HASH_CMP_NEWTYPE(SymbolName, value, CMP_STR)
 };
 
 using SymbolToInfoMap = absl::flat_hash_map<

--- a/indexer/SymbolName.h
+++ b/indexer/SymbolName.h
@@ -1,0 +1,48 @@
+#ifndef SCIP_CLANG_SYMBOL_NAME_H
+#define SCIP_CLANG_SYMBOL_NAME_H
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "indexer/Comparison.h"
+#include "indexer/Derive.h"
+#include "indexer/Enforce.h"
+
+namespace scip {
+
+/// An owned symbol name value
+class SymbolName {
+  std::string value;
+
+  // The implicitly synthesized copy constructor is important as this is
+  // used a map key, which are required to be copy-constructible.
+public:
+  SymbolName(std::string &&value) : value(std::move(value)) {
+    ENFORCE(!this->value.empty());
+  }
+  const std::string &asStringRef() const {
+    return this->value;
+  }
+  std::string &asStringRefMut() {
+    return this->value;
+  }
+  DERIVE_HASH_CMP_NEWTYPE(SymbolName, value, CMP_STR)
+};
+
+/// An unowned symbol name
+struct SymbolNameRef {
+  std::string_view value;
+
+  DERIVE_HASH_CMP_NEWTYPE(SymbolNameRef, value, CMP_STR)
+};
+
+} // namespace scip
+
+namespace scip_clang {
+
+using scip::SymbolNameRef;
+
+} // namespace scip_clang
+
+#endif // SCIP_CLANG_SYMBOL_NAME_H


### PR DESCRIPTION
Subsequently, we should introduce a type which only contains the suffix,
so it's useful to distinguish between the two, instead of just using
`std::string_view` everywhere.