### PR TITLE
fix: Gracefully handle skipped semantic analysis

### DIFF
--- a/indexer/Worker.h
+++ b/indexer/Worker.h
@@ -115,6 +115,12 @@ private:
 
   ReceiveStatus
   processTranslationUnitAndRespond(IndexJobRequest &&semanticAnalysisRequest);
+
+  ReceiveStatus sendRequestAndReceive(JobId semaRequestId,
+                                      std::string_view tuMainFilePath,
+                                      SemanticAnalysisJobResult &&,
+                                      IndexJobRequest &emitIndexRequest);
+
   void emitIndex(google::protobuf::Message &&scipIndex,
                  const StdPath &outputPath);
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/scip-clang/issues/197 as we replace
the assertion with a warning.