### PR TITLE
refactor: Properly track compdb index

### DIFF
--- a/indexer/CompilationDatabase.cc
+++ b/indexer/CompilationDatabase.cc
@@ -159,6 +159,8 @@ namespace scip_clang {
 namespace compdb {
 
 llvm::json::Value toJSON(const CommandObject &cmd) {
+  // The keys here match what is present in a compilation database.
+  // Skip the index as that's not expected by the rapidjson parser
   return llvm::json::Object{{"directory", cmd.workingDirectory},
                             {"file", cmd.filePath},
                             {"arguments", cmd.arguments}};
@@ -166,6 +168,7 @@ llvm::json::Value toJSON(const CommandObject &cmd) {
 
 bool fromJSON(const llvm::json::Value &jsonValue, CommandObject &cmd,
               llvm::json::Path path) {
+  // The keys match what is present in a compilation database.
   llvm::json::ObjectMapper mapper(jsonValue, path);
   return mapper && mapper.map("directory", cmd.workingDirectory)
          && mapper.map("file", cmd.filePath)
@@ -628,6 +631,8 @@ void ResumableParser::parseMore(std::vector<compdb::CommandObject> &out,
     }
     std::string pathBuffer;
     for (auto &cmd : this->handler->commands) {
+      cmd.index = this->currentIndex;
+      ++this->currentIndex;
       if (checkFilesExist
           && !doesFileExist(cmd.filePath, cmd.workingDirectory)) {
         continue;

--- a/indexer/CompilationDatabase.h
+++ b/indexer/CompilationDatabase.h
@@ -63,6 +63,9 @@ enum class Key : uint32_t {
 /// The 'command object' terminology is taken from the official Clang docs.
 /// https://clang.llvm.org/docs/JSONCompilationDatabase.html
 struct CommandObject {
+  static constexpr size_t POISON_INDEX = 8080808080;
+
+  size_t index = /*poison value*/ POISON_INDEX;
   /// Strictly speaking, this should be an absolute directory in an actual
   /// compilation database (see NOTE(ref: directory-field-is-absolute)),
   /// but we use a std::string instead as it may be a relative path for
@@ -108,6 +111,7 @@ class ResumableParser {
   std::optional<rapidjson::FileReadStream> compDbStream;
   std::optional<CommandObjectHandler> handler;
   rapidjson::Reader reader;
+  size_t currentIndex = 0;
 
   bool inferResourceDir;
   absl::flat_hash_set<std::string> emittedErrors;

--- a/test/Snapshot.cc
+++ b/test/Snapshot.cc
@@ -338,7 +338,7 @@ MultiTuSnapshotTest::MultiTuSnapshotTest(
 compdb::CommandObject
 CommandObjectBuilder::build(const RootPath &rootInSandbox) {
   return compdb::CommandObject{
-      std::string(rootInSandbox.asRef().asStringView()),
+      this->index, std::string(rootInSandbox.asRef().asStringView()),
       rootInSandbox.makeAbsolute(this->tuPathInSandbox).asStringRef(),
       std::move(this->commandLine)};
 }
@@ -410,6 +410,7 @@ MultiTuSnapshotTest::buildInputToOutputMap() {
 }
 
 void MultiTuSnapshotTest::iterateOverTus(PerTuCallback perTuCallback) {
+  size_t index = 0;
   for (auto &io : this->inputOutputs) {
     auto &sourceFileRelPath = io.sourceFilePath.asStringRef();
     if (!test::isTuMainFilePath(sourceFileRelPath)) {
@@ -435,8 +436,9 @@ void MultiTuSnapshotTest::iterateOverTus(PerTuCallback perTuCallback) {
         }
       }
     }
-    perTuCallback(CommandObjectBuilder{io.sourceFilePath.asRef(),
+    perTuCallback(CommandObjectBuilder{index, io.sourceFilePath.asRef(),
                                        std::move(commandLine)});
+    ++index;
   }
 }
 

--- a/test/Snapshot.h
+++ b/test/Snapshot.h
@@ -67,6 +67,7 @@ void compareDiff(std::string_view expected, std::string_view actual,
                  std::string_view errorMessage);
 
 struct CommandObjectBuilder {
+  size_t index;
   RootRelativePathRef tuPathInSandbox;
   std::vector<std::string> commandLine;
 


### PR DESCRIPTION
Some compilation database jobs can be skipped, for example,
if the main file is not present on disk. In this case,
we need to track the index at the time of validation.

Previously, we tracked the index after some elements were
potentially skipped, which would lead to incorrect indexes
being printed in logs/error messages.
