### PR TITLE
fix: Skip non-TU main file command objects

### DIFF
--- a/indexer/Worker.cc
+++ b/indexer/Worker.cc
@@ -146,7 +146,8 @@ Worker::Worker(WorkerOptions &&options)
         compdb::ValidationOptions{.checkDirectoryPathsAreAbsolute = true});
     compdb::ResumableParser parser{};
     // See FIXME(ref: resource-dir-extra)
-    parser.initialize(compdbFile, std::numeric_limits<size_t>::max(), true);
+    parser.initialize(compdbFile, std::numeric_limits<size_t>::max(),
+                      compdb::ParseOptions{/*isTesting*/ false});
     parser.parseMore(this->compileCommands);
     std::fclose(compdbFile.file);
     break;

--- a/test/compdb/skipping-4.snapshot.yaml
+++ b/test/compdb/skipping-4.snapshot.yaml
@@ -1,0 +1,20 @@
+---
+- command:
+    - abc
+  filePath:        a.c
+  directory:       not_skipped
+- command:
+    - abc
+  filePath:        a.cpp
+  directory:       not_skipped
+- command:
+    - abc
+  filePath:        a.cc
+  directory:       not_skipped
+...
+---
+- command:
+    - abc
+  filePath:        a.cxx
+  directory:       not_skipped
+...

--- a/test/compdb/skipping.json
+++ b/test/compdb/skipping.json
@@ -1,0 +1,47 @@
+[
+  {
+    "command": "abc",
+    "directory": "not_skipped",
+    "file": "a.c"
+  },
+  {
+    "command": "abc",
+    "directory": "not_skipped",
+    "file": "a.cpp"
+  },
+  {
+    "command": "abc",
+    "directory": "not_skipped",
+    "file": "a.cc"
+  },
+  {
+    "command": "abc",
+    "directory": "skipped",
+    "file": "foo.h"
+  },
+  {
+    "command": "abc",
+    "directory": "skipped",
+    "file": "foo.hpp"
+  },
+  {
+    "command": "abc",
+    "directory": "skipped",
+    "file": "foo.hxx"
+  },
+  {
+    "command": "abc",
+    "directory": "not_skipped",
+    "file": "a.cxx"
+  },
+  {
+    "command": "abc",
+    "directory": "skipped",
+    "file": "foo.def"
+  },
+  {
+    "command": "abc",
+    "directory": "skipped",
+    "file": "foo.S"
+  }
+]


### PR DESCRIPTION
When the compilation database for a codebase is generated using
grailbio/bazel-compilation-database, it ends up generating lots of
entries for headers and other template files like 'def' files in LLVM.
However, those cannot actually be semantically analyzed without
a translation unit, so skip them immediately after parsing.