### PR TITLE
fix: Prefer doc comment on definition (attempt 2)

### DIFF
--- a/test/index/docs/docs.cc
+++ b/test/index/docs/docs.cc
@@ -16,3 +16,9 @@ enum class Apink {
   //! Maknae
   Hayoung,
 };
+
+/// Ominous sounds
+struct Ghost;
+
+/// Boo!
+typedef struct Ghost {} Ghost;

--- a/test/index/docs/docs.snapshot.cc
+++ b/test/index/docs/docs.snapshot.cc
@@ -43,3 +43,16 @@
 //  documentation
 //  | Maknae
   };
+  
+  /// Ominous sounds
+  struct Ghost;
+//       ^^^^^ reference [..] Ghost#
+  
+  /// Boo!
+  typedef struct Ghost {} Ghost;
+//               ^^^^^ definition [..] Ghost#
+//               documentation
+//               | Ominous sounds
+//                        ^^^^^ definition [..] Ghost#
+//                        documentation
+//                        | Ominous sounds

--- a/test/index/docs/docs.snapshot.cc
+++ b/test/index/docs/docs.snapshot.cc
@@ -52,7 +52,7 @@
   typedef struct Ghost {} Ghost;
 //               ^^^^^ definition [..] Ghost#
 //               documentation
-//               | Ominous sounds
+//               | Boo!
 //                        ^^^^^ definition [..] Ghost#
 //                        documentation
-//                        | Ominous sounds
+//                        | Boo!


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/scip-clang/issues/284