### PR TITLE
fix: Fix crash when emitting relationships

### DIFF
--- a/indexer/Indexer.cc
+++ b/indexer/Indexer.cc
@@ -735,7 +735,7 @@ void TuIndexer::saveTagDecl(const clang::TagDecl &tagDecl) {
       continue;
     }
     if (seen.find(cxxRecordDecl) == seen.end()) {
-      // See FIXME(ref: template-specialization-support) When we get the decl
+      // FIXME(def: template-specialization-support) When we get the decl
       // symbol here, we need to handle different kinds of templates
       // differently. E.g. in the ImplicitInstantiation case, call
       // getTemplateInstantiationPattern and use that rather than using the
@@ -750,7 +750,12 @@ void TuIndexer::saveTagDecl(const clang::TagDecl &tagDecl) {
       }
       seen.insert(cxxRecordDecl);
     }
-
+    if (!cxxRecordDecl->hasDefinition()) {
+      // FIXME(def: template-specialization-support) This case
+      // can be hit when inheriting from an explicit specialization
+      // for which the unspecialized record lacks a definition.
+      continue;
+    }
     for (const clang::CXXBaseSpecifier &cxxBaseSpecifier :
          cxxRecordDecl->bases()) {
       auto baseType = cxxBaseSpecifier.getType().getCanonicalType();

--- a/test/index/types/inheritance.cc
+++ b/test/index/types/inheritance.cc
@@ -1,3 +1,5 @@
+// extra-args: -std=c++17
+
 struct MonoBase {};
 
 struct MonoDerived: MonoBase {};
@@ -36,3 +38,11 @@ struct DerivedFromTemplateParam: T {};
 
 template <template <typename> typename H>
 struct DerivedFromTemplateTemplateParam: H<int> {};
+
+template <bool, class T> struct BaseWithOnlySpecializations;
+
+template <class T>
+struct BaseWithOnlySpecializations<false, T> {};
+
+template <class T>
+struct DerivedFromBasedWithOnlySpecialization: public BaseWithOnlySpecializations<false, T> {};

--- a/test/index/types/inheritance.snapshot.cc
+++ b/test/index/types/inheritance.snapshot.cc
@@ -1,5 +1,7 @@
+  // extra-args: -std=c++17
+//^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] `<file>/inheritance.cc`/
+  
   struct MonoBase {};
-//^^^^^^ definition [..] `<file>/inheritance.cc`/
 //       ^^^^^^^^ definition [..] MonoBase#
   
   struct MonoDerived: MonoBase {};
@@ -87,3 +89,21 @@
   struct DerivedFromTemplateTemplateParam: H<int> {};
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] DerivedFromTemplateTemplateParam#
 //                                         ^ reference local 7
+  
+  template <bool, class T> struct BaseWithOnlySpecializations;
+//                      ^ definition local 8
+//                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] BaseWithOnlySpecializations#
+  
+  template <class T>
+//                ^ definition local 9
+  struct BaseWithOnlySpecializations<false, T> {};
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] BaseWithOnlySpecializations#
+//                                          ^ reference local 9
+  
+  template <class T>
+//                ^ definition local 10
+  struct DerivedFromBasedWithOnlySpecialization: public BaseWithOnlySpecializations<false, T> {};
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] DerivedFromBasedWithOnlySpecialization#
+//       relation implementation [..] BaseWithOnlySpecializations#
+//                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] BaseWithOnlySpecializations#
+//                                                                                         ^ reference local 10


### PR DESCRIPTION
When looking up base classes, we need to check if the definition
exists, as it may not for templated classes.
