### PR TITLE
debug: Add trace logging to identify out-of-project files

### DIFF
--- a/indexer/main.cc
+++ b/indexer/main.cc
@@ -179,7 +179,9 @@ static scip_clang::CliOptions parseArguments(int argc, char *argv[]) {
   cliOptions.showProgress = result.count("no-progress-report") == 0;
 
   auto level = result["log-level"].as<std::string>();
-  if (level == "debug") {
+  if (level == "trace") {
+    cliOptions.logLevel = spdlog::level::level_enum::trace;
+  } else if (level == "debug") {
     cliOptions.logLevel = spdlog::level::level_enum::debug;
   } else if (level == "info") {
     cliOptions.logLevel = spdlog::level::level_enum::info;


### PR DESCRIPTION
When investigating a customer issue, we're running into a mysterious
bug where seemingly in-project files are being considered out-of-project.
We add support for a 'trace' logging level to debug this issue,
as this logging shouldn't be needed for most debugging cases.

The trace logging level is not yet documented as we may remove it
later.