### PR TITLE
docs: Add CHANGELOG entry for v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # scip-clang ChangeLog
 
+## v0.2.4 (beta)
+
+- Adds temporary support for better debugging issues
+  where seemingly in-project files are treated as out-of-project.
+  (https://github.com/sourcegraph/scip-clang/pull/409)
+
 ## v0.2.3 (beta)
 
 - Adds support for Find implementations for classes.

--- a/indexer/Version.h
+++ b/indexer/Version.h
@@ -15,7 +15,7 @@ constexpr bool debugMode = true;
 constexpr bool debugMode = false;
 #endif
 
-#define VERSION "0.2.3"
+#define VERSION "0.2.4"
 #define LLVM_COMMIT \
   "e0f3110b854a476c16cce7b44472cd7838d344e9" // Keep synced with fetch_deps.bzl
 


### PR DESCRIPTION
To be merged after https://github.com/sourcegraph/scip-clang/pull/409