### PR TITLE
build: Change repo for Bazel toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,11 @@ common --enable_platform_specific_config
 # https://sourcegraph.com/github.com/grailbio/bazel-toolchain@d52ce5d96915428a5ee6f7079078df706c5fddab/-/blob/toolchain/cc_toolchain_config.bzl?L154:11
 build:linux --linkopt="-fuse-ld=lld"
 
+# Based on release notes from since we're on Bazel < 7
+# https://github.com/bazel-contrib/toolchains_llvm/releases/tag/0.10.3
+build:darwin --features=-supports_dynamic_linker
+build:darwin --features=-libtool
+
 # Not sure why setting all of these is necessary, but just setting cxxopt
 # Leads to usage of old C++ version when compiling LLVM, which needs C++14 or newer.
 build --cxxopt="-std=c++20" --host_cxxopt="-std=c++20" --client_env=BAZEL_CXXOPTS="-std=c++20"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ load("//:fetch_deps.bzl", "fetch_direct_dependencies")
 fetch_direct_dependencies()
 
 # Setup the toolchain before setting up other dependencies
-load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+load("@toolchains_llvm//toolchain:deps.bzl", "bazel_toolchain_dependencies")
 
 bazel_toolchain_dependencies()
 

--- a/fetch_deps.bzl
+++ b/fetch_deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 _BAZEL_SKYLIB_VERSION = "1.3.0"
 _PLATFORMS_COMMIT = "3fbc687756043fb58a407c2ea8c944bc2fe1d922"  # 2022 Nov 10
-_BAZEL_TOOLCHAIN_VERSION = "0.8.2"
+_BAZEL_TOOLCHAIN_VERSION = "0.10.3"
 _RULES_BOOST_COMMIT = "ed40cc3c6fb76fe46f40150ebb81ef6a625b6e36"
 _LLVM_COMMIT = "e0f3110b854a476c16cce7b44472cd7838d344e9"  # Keep in sync with Version.h
 _ABSL_COMMIT = "4ffaea74c1f5408e0757547a1ca0518ad43fa9f1"
@@ -43,12 +43,11 @@ def fetch_direct_dependencies():
     )
 
     http_archive(
-        name = "com_grail_bazel_toolchain",
-        sha256 = "c4436850f2edece101371b56971a760aee4b65c0800d55a8b1b8e3f52296ebdd",
-        strip_prefix = "bazel-toolchain-%s" % _BAZEL_TOOLCHAIN_VERSION,
-        urls = [
-            "https://github.com/grailbio/bazel-toolchain/archive/refs/tags/%s.zip" % _BAZEL_TOOLCHAIN_VERSION,
-        ],
+        name = "toolchains_llvm",
+        sha256 = "b7cd301ef7b0ece28d20d3e778697a5e3b81828393150bed04838c0c52963a01",
+        strip_prefix = "toolchains_llvm-%s" % _BAZEL_TOOLCHAIN_VERSION,
+        canonical_id = _BAZEL_TOOLCHAIN_VERSION,
+        url = "https://github.com/grailbio/bazel-toolchain/releases/download/{0}/toolchains_llvm-{0}.tar.gz".format(_BAZEL_TOOLCHAIN_VERSION),
     )
 
     http_archive(

--- a/setup_llvm.bzl
+++ b/setup_llvm.bzl
@@ -1,4 +1,4 @@
-load("@com_grail_bazel_toolchain//toolchain:rules.bzl", grailbio_llvm_toolchain = "llvm_toolchain")
+load("@toolchains_llvm//toolchain:rules.bzl", grailbio_llvm_toolchain = "llvm_toolchain")
 
 def setup_llvm_toolchain(name):
     # NOTE: The ASan build uses paths which involve the version.
@@ -6,6 +6,7 @@ def setup_llvm_toolchain(name):
     mapping = {
         "linux-aarch64": {"version": "15.0.6", "triple": "aarch64-linux-gnu", "sha256": "8ca4d68cf103da8331ca3f35fe23d940c1b78fb7f0d4763c1c059e352f5d1bec"},
         "linux-x86_64": {"version": "15.0.6", "triple": "x86_64-linux-gnu-ubuntu-18.04", "sha256": "38bc7f5563642e73e69ac5626724e206d6d539fbef653541b34cae0ba9c3f036"},
+        "darwin-aarch64": {"version": "15.0.6", "triple": "arm64-apple-darwin21.0", "sha256": "32bc7b8eee3d98f72dd4e5651e6da990274ee2d28c5c19a7d8237eb817ce8d91"},
         "darwin-arm64": {"version": "15.0.6", "triple": "arm64-apple-darwin21.0", "sha256": "32bc7b8eee3d98f72dd4e5651e6da990274ee2d28c5c19a7d8237eb817ce8d91"},
         "darwin-x86_64": {"version": "15.0.7", "triple": "x86_64-apple-darwin21.0", "sha256": "d16b6d536364c5bec6583d12dd7e6cf841b9f508c4430d9ee886726bd9983f1c"},
         "windows": {"version": "15.0.6", "sha256": "22e2f2c38be4c44db7a1e9da5e67de2a453c5b4be9cf91e139592a63877ac0a2", "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/LLVM-15.0.6-win64.exe"},


### PR DESCRIPTION
The old repo under grailbio/bazel-toolchain was moved to
bazel-contrib/toolchains_llvm, and I got a CI failure when
trying to download the zip here because the checksum changed:
https://buildkite.com/sourcegraph/scip-clang/builds/1160#018db04f-44fe-40a4-9bcf-722b923d440f