### PR TITLE
ci: Use macOS 14 arm64 runner, not x86_64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,10 @@ jobs:
           - platform: 'ubuntu-22.04'
             container: 'gcc:9.5.0-buster'
             config: 'release'
-          # NOTE: GitHub-hosted runners for macOS are x86_64 only
-          # https://github.com/github/roadmap/issues/528
-          - platform: 'macos-12'
+          # macOS 14 => arm64
+          - platform: 'macos-14'
             container: ''
             config: 'release'
-          # Seeing an inexplicable
-          #   ld: file not found: external/llvm_toolchain_llvm/lib/clang/15.0.7/lib/darwin/libclang_rt.asan_osx_dynamic.dylib
-          # when running the dev build in in GitHub Actions
     runs-on: ${{ matrix.platform }}
     container: ${{ matrix.container }}
     env:

--- a/fetch_deps.bzl
+++ b/fetch_deps.bzl
@@ -210,22 +210,22 @@ def fetch_direct_dependencies():
     http_archive(
         name = "actionlint_darwin_arm64",
         build_file = "@scip_clang//third_party:actionlint.BUILD",
-        sha256 = "5477f8a5a4073ef086525a2512b2bf1201641cd544034ad0c66f329590638242",
-        urls = ["https://github.com/rhysd/actionlint/releases/download/v1.6.24/actionlint_1.6.24_darwin_arm64.tar.gz"],
+        sha256 = "4b8eff986643b8d9918c4fd3ada9c0eee7e59230a53a46a9bd9686521dcad170",
+        urls = ["https://github.com/rhysd/actionlint/releases/download/v1.6.27/actionlint_1.6.27_darwin_arm64.tar.gz"],
     )
 
     http_archive(
         name = "actionlint_linux_amd64",
         build_file = "@scip_clang//third_party:actionlint.BUILD",
-        sha256 = "3c5818744143a5d6754edd3dcc4c2b32c9dfcdd3bb30e0e108fb5e5c505262d4",
-        urls = ["https://github.com/rhysd/actionlint/releases/download/v1.6.24/actionlint_1.6.24_linux_amd64.tar.gz"],
+        sha256 = "5c9b6e5418f688b7f7c7e3d40c13d9e41b1ca45fb6a2c35788b0580e34b7300f",
+        urls = ["https://github.com/rhysd/actionlint/releases/download/v1.6.27/actionlint_1.6.27_linux_amd64.tar.gz"],
     )
 
     http_archive(
         name = "actionlint_linux_arm64",
         build_file = "@scip_clang//third_party:actionlint.BUILD",
-        sha256 = "93cc9d1f4a01f0658423b41ecf3bd8c17c619003ec683be8bac9264d0361d0d8",
-        urls = ["https://github.com/rhysd/actionlint/releases/download/v1.6.24/actionlint_1.6.24_linux_arm64.tar.gz"],
+        sha256 = "03ffe5891da7800ec39533543667697b5c292d0ff8b906397b43c58374ec052a",
+        urls = ["https://github.com/rhysd/actionlint/releases/download/v1.6.27/actionlint_1.6.27_linux_arm64.tar.gz"],
     )
 
     http_archive(

--- a/fetch_deps.bzl
+++ b/fetch_deps.bzl
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 _BAZEL_SKYLIB_VERSION = "1.3.0"
 _PLATFORMS_COMMIT = "3fbc687756043fb58a407c2ea8c944bc2fe1d922"  # 2022 Nov 10
 _BAZEL_TOOLCHAIN_VERSION = "0.10.3"
-_RULES_BOOST_COMMIT = "ed40cc3c6fb76fe46f40150ebb81ef6a625b6e36"
+_RULES_BOOST_COMMIT = "00b9b9ecb9b43564de44ea0b10e22b29dcf84d79"
 _LLVM_COMMIT = "e0f3110b854a476c16cce7b44472cd7838d344e9"  # Keep in sync with Version.h
 _ABSL_COMMIT = "4ffaea74c1f5408e0757547a1ca0518ad43fa9f1"
 _CXXOPTS_VERSION = "3.0.0"
@@ -52,7 +52,7 @@ def fetch_direct_dependencies():
 
     http_archive(
         name = "com_github_nelhage_rules_boost",
-        sha256 = "2f3120bb4dd42ad58ff5677d4fa6ecbab34a93d94a8ad66f9b07951bff59cdbf",
+        sha256 = "a8499f581899ae7356e40e2aab6e985dd2da9c894c91197341aace9a0a6157fe",
         strip_prefix = "rules_boost-%s" % _RULES_BOOST_COMMIT,
         urls = [
             "https://github.com/nelhage/rules_boost/archive/%s.tar.gz" % _RULES_BOOST_COMMIT,

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -3,9 +3,7 @@ set -euo pipefail
 
 PROJECT_ROOT="$(dirname "${BASH_SOURCE[0]}")/.."
 
-if [ ! -f "bazel-bin/third_party/actionlint" ]; then
-  bazel build //third_party:actionlint
-fi
+bazel build //third_party:actionlint
 
 (
   cd "$PROJECT_ROOT"


### PR DESCRIPTION
Let's see if the release binaries get built properly.