### PR TITLE
build: Bump compilation toolchain

### DIFF
--- a/settings.bzl
+++ b/settings.bzl
@@ -1,7 +1,5 @@
 # Keep LLVM versions list in sync with setup_llvm.bzl
 ASAN_LINKOPTS = [
-    "-Wl,-rpath,@loader_path/../../../../../../external/llvm_toolchain_llvm/lib/clang/15.0.6/lib/darwin",
-    # macOS release builds use 15.0.7 for x86_64
-    "-Wl,-rpath,@loader_path/../../../../../../external/llvm_toolchain_llvm/lib/clang/15.0.7/lib/darwin",
-    "-Wl,-rpath,@loader_path/../../../../../../external/llvm_toolchain_llvm/lib/clang/15.0.6/lib/linux",
+    "-Wl,-rpath,@loader_path/../../../../../../external/llvm_toolchain_llvm/lib/clang/17.0.6/lib/darwin",
+    "-Wl,-rpath,@loader_path/../../../../../../external/llvm_toolchain_llvm/lib/clang/17.0.6/lib/linux",
 ]

--- a/setup_llvm.bzl
+++ b/setup_llvm.bzl
@@ -4,12 +4,10 @@ def setup_llvm_toolchain(name):
     # NOTE: The ASan build uses paths which involve the version.
     # Keep the version list in sync with settings.bzl
     mapping = {
-        "linux-aarch64": {"version": "15.0.6", "triple": "aarch64-linux-gnu", "sha256": "8ca4d68cf103da8331ca3f35fe23d940c1b78fb7f0d4763c1c059e352f5d1bec"},
-        "linux-x86_64": {"version": "15.0.6", "triple": "x86_64-linux-gnu-ubuntu-18.04", "sha256": "38bc7f5563642e73e69ac5626724e206d6d539fbef653541b34cae0ba9c3f036"},
-        "darwin-aarch64": {"version": "15.0.6", "triple": "arm64-apple-darwin21.0", "sha256": "32bc7b8eee3d98f72dd4e5651e6da990274ee2d28c5c19a7d8237eb817ce8d91"},
-        "darwin-arm64": {"version": "15.0.6", "triple": "arm64-apple-darwin21.0", "sha256": "32bc7b8eee3d98f72dd4e5651e6da990274ee2d28c5c19a7d8237eb817ce8d91"},
-        "darwin-x86_64": {"version": "15.0.7", "triple": "x86_64-apple-darwin21.0", "sha256": "d16b6d536364c5bec6583d12dd7e6cf841b9f508c4430d9ee886726bd9983f1c"},
-        "windows": {"version": "15.0.6", "sha256": "22e2f2c38be4c44db7a1e9da5e67de2a453c5b4be9cf91e139592a63877ac0a2", "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/LLVM-15.0.6-win64.exe"},
+        "linux-aarch64": {"version": "17.0.6", "triple": "aarch64-linux-gnu", "sha256": "6dd62762285326f223f40b8e4f2864b5c372de3f7de0731cb7cd55ca5287b75a"},
+        "linux-x86_64": {"version": "17.0.6", "triple": "x86_64-linux-gnu-ubuntu-22.04", "sha256": "884ee67d647d77e58740c1e645649e29ae9e8a6fe87c1376be0f3a30f3cc9ab3"},
+        "darwin-aarch64": {"version": "17.0.6", "triple": "arm64-apple-darwin22.0", "sha256": "1264eb3c2a4a6d5e9354c3e5dc5cb6c6481e678f6456f36d2e0e566e9400fcad"},
+        "darwin-arm64": {"version": "17.0.6", "triple": "arm64-apple-darwin22.0", "sha256": "1264eb3c2a4a6d5e9354c3e5dc5cb6c6481e678f6456f36d2e0e566e9400fcad"},
     }
     llvm_versions, sha256, strip_prefix, urls = {}, {}, {}, {}
     for (k, v) in mapping.items():


### PR DESCRIPTION
Previously, we were using Clang 15.0.6 which had a bug
that would trigger when compiling Clang HEAD in C++20 mode.

```
external/llvm-project/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp:503:12: error: ISO C++20 does not permit initialization of char array with UTF-8 string literal
      char ConvergenceMarker[] = u8"\\n\u2192\u007c";
           ^
```

This prevented us from bumping the LLVM version we
build/link against. So bump Clang so that we can bump Clang.