### PR TITLE
Implements support for the `enclosing_range` field in SCIP occurrences,

### DIFF
--- a/fetch_deps.bzl
+++ b/fetch_deps.bzl
@@ -11,7 +11,7 @@ _RAPIDJSON_COMMIT = "a98e99992bd633a2736cc41f96ec85ef0c50e44d"
 _WYHASH_COMMIT = "ea3b25e1aef55d90f707c3a292eeb9162e2615d8"
 _SPDLOG_COMMIT = "edc51df1bdad8667b628999394a1e7c4dc6f3658"
 _PROTOBUF_VERSION = "3.21.12"
-_SCIP_COMMIT = "aa0e511dcfefbacc3b96dcc2fe2abd9894416b1e"
+_SCIP_COMMIT = "9d5796159c97c3b107355c424f6c06fb1a0ea01c"
 _UTFCPP_VERSION = "4.0.5"
 # ^ When bumping this version, check if any new fields are introduced
 # in the types for which we implement hashing and comparison in
@@ -117,7 +117,7 @@ def fetch_direct_dependencies():
 
     http_archive(
         name = "scip",
-        sha256 = "b1d2fc009345857aa32cdddec11b75ce1e5c20430f668044231ed309d48b7355",
+        sha256 = "de37d2118ce87a817d627a7c8056630b7815f4477bbf1838dc46507e89275bb4",
         build_file = "@scip_clang//third_party:scip.BUILD",
         strip_prefix = "scip-%s" % _SCIP_COMMIT,
         urls = ["https://github.com/sourcegraph/scip/archive/%s.zip" % _SCIP_COMMIT],

--- a/indexer/Indexer.h
+++ b/indexer/Indexer.h
@@ -14,6 +14,7 @@
 
 #include "clang/AST/RawCommentList.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
 
 #include "indexer/ApproximateNameResolver.h"
 #include "indexer/ClangAstMacros.h"
@@ -37,13 +38,13 @@ FOR_EACH_TYPE_TO_BE_INDEXED(FORWARD_DECLARE)
 class ASTContext;
 class Decl;
 class DeclarationNameInfo;
+class FileID;
 class LangOptions;
 class MacroDefinition;
 class MacroInfo;
 class NamedDecl;
 class NestedNameSpecifierLoc;
 class QualType;
-class SourceManager;
 class TagDecl;
 class TagTypeLoc;
 class Token;
@@ -370,7 +371,8 @@ private:
 
   void saveReference(SymbolNameRef symbol, clang::SourceLocation loc,
                      const clang::Decl *maybeFwdDecl = nullptr,
-                     int32_t extraRoles = 0);
+                     int32_t extraRoles = 0,
+                     clang::SourceRange enclosingRange = {});
 
   /// Helper method for recording a \c scip::Occurrence and a
   /// \c scip::SymbolInformation for a definition.
@@ -380,7 +382,8 @@ private:
   /// For local variables, \param symbolInfo should be \c std::nullopt.
   void saveDefinition(SymbolNameRef symbol, clang::SourceLocation loc,
                       std::optional<scip::SymbolInformation> &&symbolInfo,
-                      int32_t extraRoles = 0);
+                      int32_t extraRoles = 0,
+                      clang::SourceRange enclosingRange = {});
 
   /// Only for use inside \c saveDefinition.
   void saveExternalSymbol(SymbolNameRef symbol, scip::SymbolInformation &&);
@@ -395,12 +398,14 @@ private:
   /// since SCIP only tracks SymbolInformation values in external code.
   PartialDocument &saveOccurrence(SymbolNameRef symbol,
                                   clang::SourceLocation loc,
-                                  int32_t allRoles = 0);
+                                  int32_t allRoles = 0,
+                                  clang::SourceRange enclosingRange = {});
 
   PartialDocument &saveOccurrenceImpl(SymbolNameRef symbol,
                                       FileLocalSourceRange range,
                                       clang::FileID fileId,
-                                      int32_t allRoles = 0);
+                                      int32_t allRoles = 0,
+                                      FileLocalSourceRange enclosingRange = {});
 
   DocComment getDocComment(const clang::Decl &) const;
 };


### PR DESCRIPTION
# Summary
Implements support for the `enclosing_range` field in SCIP occurrences, enabling IDE features like:
- Call hierarchies (determining symbol references within function bodies)
  - Symbol outline/breadcrumbs (showing path from cursor to file root)
  - Expand selection (selecting nearest enclosing AST node)
  - Highlight range (indicating AST expression boundaries for hovers)

# Changes
## 1. Updated SCIP Dependency

Updated schema to SCIP commit `9d5796159c97c3b107355c424f6c06fb1a0ea01c`
  which includes:
  - The `enclosing_range` field definition in the protobuf schema
  - The `add_enclosing_range()` API for populating individual values

## 2. Extended Indexer API

  Added `clang::SourceRange enclosingRange` parameter (with default
  empty value) to:
  - `TuIndexer::saveDefinition()`
  - `TuIndexer::saveReference()`
  - `TuIndexer::saveOccurrence()`
  - `TuIndexer::saveOccurrenceImpl()`

## 3. Implemented Range Population

  Modified `saveOccurrenceImpl()` to populate the `enclosing_range`
  field:
  - Format: `[startLine-1, startColumn-1, [endLine-1], endColumn-1]`
  - Uses 0-based coordinates as per SCIP specification
  - Omits endLine if range is single-line
  - Only populates when valid range is provided